### PR TITLE
Add ID and data to UserEvent and use it for 'research complete'

### DIFF
--- a/framework/event.cpp
+++ b/framework/event.cpp
@@ -14,6 +14,11 @@ FingerEvent::FingerEvent(EventTypes type) : Event(type) {}
 TimerEvent::TimerEvent(EventTypes type) : Event(type) {}
 FormsEvent::FormsEvent() : Event(EVENT_FORM_INTERACTION) {}
 TextEvent::TextEvent() : Event(EVENT_TEXT_INPUT) {}
+UserEvent::UserEvent(const UString &id, sp<void> data) : Event(EVENT_USER)
+{
+	Data.ID = id;
+	Data.data = data;
+}
 
 EventTypes Event::Type() const { return this->eventType; }
 
@@ -66,6 +71,12 @@ FRAMEWORK_TEXT_EVENT &Event::Text()
 	return ev->Data;
 }
 
+FRAMEWORK_USER_EVENT &Event::User()
+{
+	auto *ev = static_cast<UserEvent *>(this);
+	return ev->Data;
+}
+
 const FRAMEWORK_DISPLAY_EVENT &Event::Display() const
 {
 	auto *ev = static_cast<const DisplayEvent *>(this);
@@ -111,6 +122,11 @@ const FRAMEWORK_FORMS_EVENT &Event::Forms() const
 const FRAMEWORK_TEXT_EVENT &Event::Text() const
 {
 	auto *ev = static_cast<const TextEvent *>(this);
+	return ev->Data;
+}
+const FRAMEWORK_USER_EVENT &Event::User() const
+{
+	auto *ev = static_cast<const UserEvent *>(this);
 	return ev->Data;
 }
 

--- a/framework/event.h
+++ b/framework/event.h
@@ -111,6 +111,13 @@ typedef struct FRAMEWORK_TEXT_EVENT
 	UString Input;
 } FRAMEWORK_TEXT_EVENT;
 
+struct FRAMEWORK_USER_EVENT
+{
+	UString ID;
+	sp<void> data;
+	template <typename T> sp<T> dataAs() { return std::static_pointer_cast<T>(this->data); }
+};
+
 /*
      Class: Event
      Provides data regarding events that occur within the system
@@ -134,6 +141,7 @@ class Event
 	FRAMEWORK_TIMER_EVENT &Timer();
 	FRAMEWORK_FORMS_EVENT &Forms();
 	FRAMEWORK_TEXT_EVENT &Text();
+	FRAMEWORK_USER_EVENT &User();
 
 	const FRAMEWORK_DISPLAY_EVENT &Display() const;
 	const FRAMEWORK_JOYSTICK_EVENT &Joystick() const;
@@ -143,6 +151,7 @@ class Event
 	const FRAMEWORK_TIMER_EVENT &Timer() const;
 	const FRAMEWORK_FORMS_EVENT &Forms() const;
 	const FRAMEWORK_TEXT_EVENT &Text() const;
+	const FRAMEWORK_USER_EVENT &User() const;
 
 	virtual ~Event() = default;
 };
@@ -233,6 +242,17 @@ class TextEvent : public Event
   public:
 	TextEvent();
 	~TextEvent() override = default;
+};
+
+class UserEvent : public Event
+{
+  private:
+	FRAMEWORK_USER_EVENT Data;
+	friend class Event;
+
+  public:
+	UserEvent(const UString &id, sp<void> data = nullptr);
+	~UserEvent() override = default;
 };
 
 }; // namespace OpenApoc

--- a/framework/framework.cpp
+++ b/framework/framework.cpp
@@ -739,8 +739,7 @@ void Framework::Display_Initialise()
 		display_flags |= SDL_WINDOW_FULLSCREEN;
 	}
 
-	p->window = SDL_CreateWindow("OpenApoc", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, scrW,
-	                             scrH, display_flags);
+	p->window = SDL_CreateWindow("OpenApoc", 0, 0, scrW, scrH, display_flags);
 
 	if (!p->window)
 	{
@@ -966,6 +965,12 @@ void Framework::Audio_Shutdown()
 sp<Stage> Framework::Stage_GetPrevious() { return p->ProgramStages.Previous(); }
 
 sp<Stage> Framework::Stage_GetPrevious(sp<Stage> From) { return p->ProgramStages.Previous(From); }
+
+void Framework::Stage_Push(sp<Stage> stage)
+{
+	assert(stage);
+	p->ProgramStages.Push(stage);
+}
 
 Vec2<int> Framework::getCursorPosition() { return this->cursor->getPosition(); }
 

--- a/framework/framework.h
+++ b/framework/framework.h
@@ -73,6 +73,8 @@ class Framework
 	sp<Stage> Stage_GetPrevious();
 	sp<Stage> Stage_GetPrevious(sp<Stage> From);
 
+	void Stage_Push(sp<Stage> stage);
+
 	Vec2<int> getCursorPosition();
 
 	void Text_StartInput();

--- a/game/state/research.h
+++ b/game/state/research.h
@@ -42,6 +42,7 @@ class ResearchTopic : public StateObject<ResearchTopic>
 	static const std::map<LabSize, UString> LabSizeMap;
 	UString name;
 	UString description;
+	// FIXME: Some research topics enable multiple ufopaedia entries?
 	StateRef<UfopaediaEntry> ufopaedia_entry;
 	unsigned man_hours;
 	unsigned man_hours_progress;
@@ -104,6 +105,14 @@ class Lab : public StateObject<Lab>
 	// This is also used to 'store' the remaining time if the update granularity is such that is
 	// overshoots a project's completion.
 	unsigned int ticks_since_last_progress;
+};
+
+class ResearchCompleteData
+{
+  public:
+	StateRef<ResearchTopic> topic;
+	StateRef<Lab> lab;
+	std::list<StateRef<UfopaediaEntry>> ufopaedia_entries;
 };
 
 class ResearchState

--- a/game/state/ufopaedia.cpp
+++ b/game/state/ufopaedia.cpp
@@ -1,4 +1,5 @@
 #include "game/state/ufopaedia.h"
+#include "game/state/gamestate.h"
 #include "game/state/research.h"
 
 namespace OpenApoc
@@ -16,5 +17,29 @@ const std::map<UfopaediaEntry::Data, UString> UfopaediaEntry::DataMap = {
 UfopaediaEntry::UfopaediaEntry() : data_type(Data::Nothing) {}
 
 bool UfopaediaEntry::isVisible() const { return this->dependency.satisfied(); }
+
+template <>
+sp<UfopaediaEntry> StateObject<UfopaediaEntry>::get(const GameState &state, const UString &id)
+{
+	for (auto &cat : state.ufopaedia)
+	{
+		auto entry = cat.second->entries.find(id);
+		if (entry != cat.second->entries.end())
+			return entry->second;
+	}
+	LogError("No UFOPaedia entry matching ID \"%s\"", id.c_str());
+	return nullptr;
+}
+
+template <> const UString &StateObject<UfopaediaEntry>::getPrefix()
+{
+	static UString prefix = "PAEDIAENTRY_";
+	return prefix;
+}
+template <> const UString &StateObject<UfopaediaEntry>::getTypeName()
+{
+	static UString name = "UfopaediaEntry";
+	return name;
+}
 
 } // namespace OpenApoc

--- a/game/state/ufopaedia.h
+++ b/game/state/ufopaedia.h
@@ -38,7 +38,7 @@ class UfopaediaEntry : public StateObject<UfopaediaEntry>
 	bool isVisible() const;
 };
 
-class UfopaediaCategory
+class UfopaediaCategory : public StateObject<UfopaediaCategory>
 {
   public:
 	UString title;

--- a/game/ui/ufopaedia/ufopaediacategoryview.cpp
+++ b/game/ui/ufopaedia/ufopaediacategoryview.cpp
@@ -9,9 +9,30 @@
 namespace OpenApoc
 {
 
-UfopaediaCategoryView::UfopaediaCategoryView(sp<GameState> state, sp<UfopaediaCategory> cat)
+UfopaediaCategoryView::UfopaediaCategoryView(sp<GameState> state, sp<UfopaediaCategory> cat,
+                                             sp<UfopaediaEntry> entry)
     : Stage(), menuform(ui().GetForm("FORM_UFOPAEDIA_BASE")), state(state), category(cat)
 {
+	// Start with the intro page
+	this->position_iterator = this->category->entries.end();
+	if (entry)
+	{
+		auto it = cat->entries.begin();
+		while (it != cat->entries.end())
+		{
+			if (it->second == entry)
+			{
+				position_iterator = it;
+				break;
+			}
+			it++;
+		}
+		if (it == cat->entries.end())
+		{
+			LogError("Failed to find UFOpaedia entry %s in category %s", entry->title.c_str(),
+			         cat->title.c_str());
+		}
+	}
 }
 
 UfopaediaCategoryView::~UfopaediaCategoryView() {}
@@ -80,8 +101,6 @@ void UfopaediaCategoryView::Begin()
 		value->SetText("");
 		orgValues.push_back(value);
 	}
-	// Start with the intro page
-	this->position_iterator = this->category->entries.end();
 	this->setFormData();
 }
 

--- a/game/ui/ufopaedia/ufopaediacategoryview.h
+++ b/game/ui/ufopaedia/ufopaediacategoryview.h
@@ -29,7 +29,8 @@ class UfopaediaCategoryView : public Stage
 	void setFormStats();
 
   public:
-	UfopaediaCategoryView(sp<GameState> state, sp<UfopaediaCategory> cat);
+	UfopaediaCategoryView(sp<GameState> state, sp<UfopaediaCategory> cat,
+	                      sp<UfopaediaEntry> entry = nullptr);
 	~UfopaediaCategoryView();
 
 	// Stage control


### PR DESCRIPTION
I don't really know if continually extending the already creaking Event system is the best idea... Should I push this now, or try to make Events cleaner, or fixup the ufopaedia_entry pointer from a ResearchTopic first?

Note: Currently the ResearchTopic::ufopaedia_entry field is not filled
out so it doesn't actually show the ufopaedia entry if you click
'yes'...

The ufoapedia_entry probably should be a list anyway, as some things
enable multiple entries (e.g. the toxigun research topic has entries for
the gun and ammo type A)