### PR TITLE
teleporters. item throwing, collision and battletileview improvements

### DIFF
--- a/data/animationpacks/unit/checksum.xml
+++ b/data/animationpacks/unit/checksum.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <checksums>
   <checksum SHA1="61e89dde91f71522666df689a444f22b00df0712">animationpack.xml</checksum>
-  <checksum SHA1="635526859e4ab1bfabe030037c735e518766018a">animationpack/body_state_animations.xml</checksum>
+  <checksum SHA1="d518deb1470a3576962e1263b242d2ab6d24fc04">animationpack/body_state_animations.xml</checksum>
   <checksum SHA1="87469e02c3a38e59de02da0d4c0b03be0aa2a6f9">animationpack/hand_state_animations.xml</checksum>
   <checksum SHA1="1aaf26aca5bd9f094a7f95d4d5ead1bce149f6a1">animationpack/standart_animations.xml</checksum>
 </checksums>

--- a/data/difficulty1_patched/checksum.xml
+++ b/data/difficulty1_patched/checksum.xml
@@ -8,7 +8,7 @@
   <checksum SHA1="665676441df08bedc9cdd1dec8854d5b99a8ed4f">gamestate/agent_types.xml</checksum>
   <checksum SHA1="0b1fc22224d3d4d266780fe20b1db95ee052bba0">gamestate/base_layouts.xml</checksum>
   <checksum SHA1="23e3874d1ed51670e14c492e0ed06b374372fbaf">gamestate/battle_common_image_list.xml</checksum>
-  <checksum SHA1="017d5a722c573625e06ed3a236f14b4f7498fda8">gamestate/battle_common_sample_list.xml</checksum>
+  <checksum SHA1="5fbc9dc088736f547d742fa3ff3da34dc35e1941">gamestate/battle_common_sample_list.xml</checksum>
   <checksum SHA1="dcebd55d2b40ea7b7c117ce16ee71ab23be4e4ef">gamestate/battle_maps.xml</checksum>
   <checksum SHA1="09a0229c616b482ad6f16bdf5f90d879e648fb62">gamestate/battle_maps/BATTLEMAP_01senate.xml</checksum>
   <checksum SHA1="a2febcae82bb3cf12d7502ead958bc85f6ac01dc">gamestate/battle_maps/BATTLEMAP_02police.xml</checksum>

--- a/data/difficulty1_patched/gamestate/battle_common_sample_list.xml
+++ b/data/difficulty1_patched/gamestate/battle_common_sample_list.xml
@@ -4,6 +4,7 @@
     <gravlift>RAWSOUND:xcom3/rawsound/zextra/gravlift.raw:22050</gravlift>
     <door>RAWSOUND:xcom3/rawsound/tactical/terrain/doorwhsh.raw:22050</door>
     <brainsuckerHatch>RAWSOUND:xcom3/rawsound/extra/brhatch.raw:22050</brainsuckerHatch>
+    <teleport>RAWSOUND:xcom3/rawsound/tactical/explosns/teleport.raw:22050</teleport>
     <walkSounds>
       <entry>
         <sp>

--- a/data/difficulty2_patched/checksum.xml
+++ b/data/difficulty2_patched/checksum.xml
@@ -8,7 +8,7 @@
   <checksum SHA1="665676441df08bedc9cdd1dec8854d5b99a8ed4f">gamestate/agent_types.xml</checksum>
   <checksum SHA1="0b1fc22224d3d4d266780fe20b1db95ee052bba0">gamestate/base_layouts.xml</checksum>
   <checksum SHA1="23e3874d1ed51670e14c492e0ed06b374372fbaf">gamestate/battle_common_image_list.xml</checksum>
-  <checksum SHA1="017d5a722c573625e06ed3a236f14b4f7498fda8">gamestate/battle_common_sample_list.xml</checksum>
+  <checksum SHA1="5fbc9dc088736f547d742fa3ff3da34dc35e1941">gamestate/battle_common_sample_list.xml</checksum>
   <checksum SHA1="dcebd55d2b40ea7b7c117ce16ee71ab23be4e4ef">gamestate/battle_maps.xml</checksum>
   <checksum SHA1="09a0229c616b482ad6f16bdf5f90d879e648fb62">gamestate/battle_maps/BATTLEMAP_01senate.xml</checksum>
   <checksum SHA1="a2febcae82bb3cf12d7502ead958bc85f6ac01dc">gamestate/battle_maps/BATTLEMAP_02police.xml</checksum>

--- a/data/difficulty2_patched/gamestate/battle_common_sample_list.xml
+++ b/data/difficulty2_patched/gamestate/battle_common_sample_list.xml
@@ -4,6 +4,7 @@
     <gravlift>RAWSOUND:xcom3/rawsound/zextra/gravlift.raw:22050</gravlift>
     <door>RAWSOUND:xcom3/rawsound/tactical/terrain/doorwhsh.raw:22050</door>
     <brainsuckerHatch>RAWSOUND:xcom3/rawsound/extra/brhatch.raw:22050</brainsuckerHatch>
+    <teleport>RAWSOUND:xcom3/rawsound/tactical/explosns/teleport.raw:22050</teleport>
     <walkSounds>
       <entry>
         <sp>

--- a/data/difficulty3_patched/checksum.xml
+++ b/data/difficulty3_patched/checksum.xml
@@ -8,7 +8,7 @@
   <checksum SHA1="665676441df08bedc9cdd1dec8854d5b99a8ed4f">gamestate/agent_types.xml</checksum>
   <checksum SHA1="0b1fc22224d3d4d266780fe20b1db95ee052bba0">gamestate/base_layouts.xml</checksum>
   <checksum SHA1="23e3874d1ed51670e14c492e0ed06b374372fbaf">gamestate/battle_common_image_list.xml</checksum>
-  <checksum SHA1="017d5a722c573625e06ed3a236f14b4f7498fda8">gamestate/battle_common_sample_list.xml</checksum>
+  <checksum SHA1="5fbc9dc088736f547d742fa3ff3da34dc35e1941">gamestate/battle_common_sample_list.xml</checksum>
   <checksum SHA1="dcebd55d2b40ea7b7c117ce16ee71ab23be4e4ef">gamestate/battle_maps.xml</checksum>
   <checksum SHA1="09a0229c616b482ad6f16bdf5f90d879e648fb62">gamestate/battle_maps/BATTLEMAP_01senate.xml</checksum>
   <checksum SHA1="a2febcae82bb3cf12d7502ead958bc85f6ac01dc">gamestate/battle_maps/BATTLEMAP_02police.xml</checksum>

--- a/data/difficulty3_patched/gamestate/battle_common_sample_list.xml
+++ b/data/difficulty3_patched/gamestate/battle_common_sample_list.xml
@@ -4,6 +4,7 @@
     <gravlift>RAWSOUND:xcom3/rawsound/zextra/gravlift.raw:22050</gravlift>
     <door>RAWSOUND:xcom3/rawsound/tactical/terrain/doorwhsh.raw:22050</door>
     <brainsuckerHatch>RAWSOUND:xcom3/rawsound/extra/brhatch.raw:22050</brainsuckerHatch>
+    <teleport>RAWSOUND:xcom3/rawsound/tactical/explosns/teleport.raw:22050</teleport>
     <walkSounds>
       <entry>
         <sp>

--- a/data/difficulty4_patched/checksum.xml
+++ b/data/difficulty4_patched/checksum.xml
@@ -8,7 +8,7 @@
   <checksum SHA1="665676441df08bedc9cdd1dec8854d5b99a8ed4f">gamestate/agent_types.xml</checksum>
   <checksum SHA1="0b1fc22224d3d4d266780fe20b1db95ee052bba0">gamestate/base_layouts.xml</checksum>
   <checksum SHA1="23e3874d1ed51670e14c492e0ed06b374372fbaf">gamestate/battle_common_image_list.xml</checksum>
-  <checksum SHA1="017d5a722c573625e06ed3a236f14b4f7498fda8">gamestate/battle_common_sample_list.xml</checksum>
+  <checksum SHA1="5fbc9dc088736f547d742fa3ff3da34dc35e1941">gamestate/battle_common_sample_list.xml</checksum>
   <checksum SHA1="dcebd55d2b40ea7b7c117ce16ee71ab23be4e4ef">gamestate/battle_maps.xml</checksum>
   <checksum SHA1="09a0229c616b482ad6f16bdf5f90d879e648fb62">gamestate/battle_maps/BATTLEMAP_01senate.xml</checksum>
   <checksum SHA1="a2febcae82bb3cf12d7502ead958bc85f6ac01dc">gamestate/battle_maps/BATTLEMAP_02police.xml</checksum>

--- a/data/difficulty4_patched/gamestate/battle_common_sample_list.xml
+++ b/data/difficulty4_patched/gamestate/battle_common_sample_list.xml
@@ -4,6 +4,7 @@
     <gravlift>RAWSOUND:xcom3/rawsound/zextra/gravlift.raw:22050</gravlift>
     <door>RAWSOUND:xcom3/rawsound/tactical/terrain/doorwhsh.raw:22050</door>
     <brainsuckerHatch>RAWSOUND:xcom3/rawsound/extra/brhatch.raw:22050</brainsuckerHatch>
+    <teleport>RAWSOUND:xcom3/rawsound/tactical/explosns/teleport.raw:22050</teleport>
     <walkSounds>
       <entry>
         <sp>

--- a/data/difficulty5_patched/checksum.xml
+++ b/data/difficulty5_patched/checksum.xml
@@ -8,7 +8,7 @@
   <checksum SHA1="665676441df08bedc9cdd1dec8854d5b99a8ed4f">gamestate/agent_types.xml</checksum>
   <checksum SHA1="0b1fc22224d3d4d266780fe20b1db95ee052bba0">gamestate/base_layouts.xml</checksum>
   <checksum SHA1="23e3874d1ed51670e14c492e0ed06b374372fbaf">gamestate/battle_common_image_list.xml</checksum>
-  <checksum SHA1="017d5a722c573625e06ed3a236f14b4f7498fda8">gamestate/battle_common_sample_list.xml</checksum>
+  <checksum SHA1="5fbc9dc088736f547d742fa3ff3da34dc35e1941">gamestate/battle_common_sample_list.xml</checksum>
   <checksum SHA1="dcebd55d2b40ea7b7c117ce16ee71ab23be4e4ef">gamestate/battle_maps.xml</checksum>
   <checksum SHA1="09a0229c616b482ad6f16bdf5f90d879e648fb62">gamestate/battle_maps/BATTLEMAP_01senate.xml</checksum>
   <checksum SHA1="a2febcae82bb3cf12d7502ead958bc85f6ac01dc">gamestate/battle_maps/BATTLEMAP_02police.xml</checksum>

--- a/data/difficulty5_patched/gamestate/battle_common_sample_list.xml
+++ b/data/difficulty5_patched/gamestate/battle_common_sample_list.xml
@@ -4,6 +4,7 @@
     <gravlift>RAWSOUND:xcom3/rawsound/zextra/gravlift.raw:22050</gravlift>
     <door>RAWSOUND:xcom3/rawsound/tactical/terrain/doorwhsh.raw:22050</door>
     <brainsuckerHatch>RAWSOUND:xcom3/rawsound/extra/brhatch.raw:22050</brainsuckerHatch>
+    <teleport>RAWSOUND:xcom3/rawsound/tactical/explosns/teleport.raw:22050</teleport>
     <walkSounds>
       <entry>
         <sp>

--- a/game/state/agent.h
+++ b/game/state/agent.h
@@ -19,6 +19,7 @@ class AEquipmentType;
 class BattleUnitAnimationPack;
 class Sample;
 class AgentBodyType;
+class BattleUnit;
 
 class AgentStats
 {
@@ -254,12 +255,18 @@ class Agent : public StateObject<Agent>, public std::enable_shared_from_this<Age
 
 	std::list<sp<AEquipment>> equipment;
 	bool canAddEquipment(Vec2<int> pos, StateRef<AEquipmentType> type) const;
-	// Add equipment to the first available slot of any type
-	void addEquipment(GameState &state, StateRef<AEquipmentType> type);
+	Vec2<int> findFirstSlotByType(AgentEquipmentLayout::EquipmentSlotType slotType, StateRef<AEquipmentType> type = nullptr);
+	// Add equipment by type to the first available slot of any type
+	void addEquipmentByType(GameState &state, StateRef<AEquipmentType> type);
 	// Add equipment to the first available slot of a specific type
-	void addEquipment(GameState &state, StateRef<AEquipmentType> type,
+	void addEquipmentByType(GameState &state, StateRef<AEquipmentType> type,
 	                  AgentEquipmentLayout::EquipmentSlotType slotType);
-	void addEquipment(GameState &state, Vec2<int> pos, StateRef<AEquipmentType> type);
+	// Add equipment by type to a specific position
+	void addEquipmentByType(GameState &state, Vec2<int> pos, StateRef<AEquipmentType> type);
+	// Add equipment to the first available slot of a specific type
+	void addEquipment(GameState &state, sp<AEquipment> object,
+		AgentEquipmentLayout::EquipmentSlotType slotType);
+	// Add equipment to a specific position
 	void addEquipment(GameState &state, Vec2<int> pos, sp<AEquipment> object);
 	void removeEquipment(sp<AEquipment> object);
 	void updateSpeed();
@@ -269,6 +276,9 @@ class Agent : public StateObject<Agent>, public std::enable_shared_from_this<Age
 	StateRef<AEquipmentType> getDominantItemInHands() const;
 	sp<AEquipment> getFirstItemInSlot(AgentEquipmentLayout::EquipmentSlotType type) const;
 	StateRef<BattleUnitImagePack> getImagePack(AgentType::BodyPart bodyPart) const;
+
+	// Following members are not serialized, but rather are set up in the initBattle method
+	sp<BattleUnit> unit;
 };
 
 class AgentGenerator

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -65,6 +65,10 @@ Battle::~Battle()
 		s->battle = nullptr;
 	}
 	this->map_parts.clear();
+	for (auto &u : this->units)
+	{
+		u->agent->unit = nullptr;
+	}
 	for (auto &s : this->items)
 	{
 		if (s->tileObject)
@@ -108,6 +112,7 @@ void Battle::initBattle(GameState &state)
 	for (auto &o : this->units)
 	{
 		o->battle = stt;
+		o->agent->unit = o->shared_from_this();
 	}
 	if (forces.size() == 0)
 	{
@@ -172,7 +177,11 @@ void Battle::initMap()
 	for (auto &o : this->items)
 	{
 		this->map->addObjectToMap(o);
-		o->findSupport(false);
+		if (o->supported)
+		{
+			o->supported = false;
+			o->findSupport(false, true);
+		}
 	}
 	for (auto &u : this->units)
 	{

--- a/game/state/battle/battleitem.h
+++ b/game/state/battle/battleitem.h
@@ -6,6 +6,8 @@
 #include "library/vec.h"
 #include <set>
 
+#define FALLING_ACCELERATION_ITEM 0.14285714f // 1/7th
+
 namespace OpenApoc
 {
 class TileObjectShadow;
@@ -14,17 +16,23 @@ class Collision;
 class GameState;
 class TileMap;
 class Battle;
+class BattleUnit;
 
 class BattleItem : public std::enable_shared_from_this<BattleItem>
 {
 
   public:
 	sp<AEquipment> item;
-
+	
 	Vec3<float> getPosition() const { return this->position; }
 
 	Vec3<float> position;
 	Vec3<float> velocity;
+
+	// Item can bounce once after being thrown
+	bool bounced = false;
+
+	bool supported = false;
 
 	void handleCollision(GameState &state, Collision &c);
 	void die(GameState &state, bool violently);
@@ -39,7 +47,6 @@ class BattleItem : public std::enable_shared_from_this<BattleItem>
 
 	// Following members are not serialized, but rather are set up in the initBattle method
 
-	bool supported = false;
 	sp<TileObjectBattleItem> tileObject;
 	sp<TileObjectShadow> shadowObject;
 	wp<Battle> battle;

--- a/game/state/battle/battlemap.cpp
+++ b/game/state/battle/battlemap.cpp
@@ -877,6 +877,7 @@ sp<Battle> BattleMap::createBattle(GameState &state, StateRef<Organisation> targ
 						auto s = mksp<BattleItem>();
 						s->item = i;
 						s->position = pair.first + shift;
+						s->supported = true;
 
 						b->items.push_back(s);
 					}

--- a/game/state/battle/battleunit.h
+++ b/game/state/battle/battleunit.h
@@ -16,6 +16,8 @@
 // This defines how fast a flying unit accelerates to full speed
 #define FLYING_ACCELERATION_DIVISOR 2
 
+#define FALLING_ACCELERATION_UNIT 0.16666667f // 1/6th
+
 namespace OpenApoc
 {
 
@@ -182,8 +184,11 @@ class BattleUnit : public std::enable_shared_from_this<BattleUnit>
 	// Get unit's height in current situation
 	int getCurrentHeight() const { return agent->type->bodyType->height.at(current_body_state); }
 
+	// TU functions
 	// Wether unit can afford action
-	bool canAfford(int cost) const { return agent->modified_stats.time_units >= cost; }
+	bool canAfford(int cost) const; 
+	// Returns if unit did spend (false if unsufficient TUs)
+	bool spendTU(int cost);
 
 	// If unit is asked to give way, this list will be filled with facings
 	// in order of priority that should be tried by it
@@ -198,6 +203,8 @@ class BattleUnit : public std::enable_shared_from_this<BattleUnit>
 	const Vec3<float> &getPosition() const { return this->position; }
 
 	StateRef<AEquipmentType> getDisplayedItem() const;
+
+	float getMaxThrowDistance(int weight, int heightDifference);
 
 	int getMaxHealth() const;
 	int getHealth() const;

--- a/game/state/battle/battleunitmission.h
+++ b/game/state/battle/battleunitmission.h
@@ -63,6 +63,7 @@ class BattleUnitMission
 		Turn,
 		Fall,
 		ReachGoal,
+		Teleport
 	};
 
 	// Methods used in pathfinding etc.
@@ -94,7 +95,7 @@ class BattleUnitMission
 	static BattleUnitMission *snooze(BattleUnit &u, unsigned int ticks);
 	static BattleUnitMission *acquireTU(BattleUnit &u, unsigned int tu);
 	static BattleUnitMission *changeStance(BattleUnit &u, AgentType::BodyState state);
-	static BattleUnitMission *throwItem(BattleUnit &u, sp<AEquipment> item, Vec3<int> target);
+	static BattleUnitMission *throwItem(BattleUnit &u, sp<AEquipment> item, Vec3<int> target, float velocityXY, float velocityZ);
 	static BattleUnitMission *dropItem(BattleUnit &u, sp<AEquipment> item);
 	static BattleUnitMission *turn(BattleUnit &u, Vec2<int> target, bool free = false, bool requireGoal = true);
 	static BattleUnitMission *turn(BattleUnit &u, Vec3<int> target, bool free = false, bool requireGoal = true);
@@ -102,6 +103,7 @@ class BattleUnitMission
 	static BattleUnitMission *restartNextMission(BattleUnit &u);
 	static BattleUnitMission *fall(BattleUnit &u);
 	static BattleUnitMission *reachGoal(BattleUnit &u);
+	static BattleUnitMission *teleport(BattleUnit &u, sp<AEquipment> item, Vec3<int> target);
 
 	UString getName();
 
@@ -127,8 +129,12 @@ class BattleUnitMission
 	bool requireGoal = false;
 	bool free = false;
 
-	// ThrowItem, DropItem
+	// ThrowItem, DropItem, Teleport
 	sp<AEquipment> item;
+
+	// ThrorwItem
+	float velocityXY = 0.0f;
+	float velocityZ = 0.0f;
 
 	// Snooze
 	unsigned int timeToSnooze = 0;

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -292,18 +292,18 @@ void GameState::fillPlayerStartingProperty()
 								slotType = AgentEquipmentLayout::EquipmentSlotType::ArmorRightHand;
 								break;
 						}
-						agent->addEquipment(*this, {this, t->id}, slotType);
+						agent->addEquipmentByType(*this, {this, t->id}, slotType);
 					}
 					else if (t->type == AEquipmentType::Type::Ammo ||
 					         t->type == AEquipmentType::Type::MediKit ||
 					         t->type == AEquipmentType::Type::Grenade)
 					{
-						agent->addEquipment(*this, {this, t->id},
+						agent->addEquipmentByType(*this, {this, t->id},
 						                    AgentEquipmentLayout::EquipmentSlotType::General);
 					}
 					else
 					{
-						agent->addEquipment(*this, {this, t->id});
+						agent->addEquipmentByType(*this, {this, t->id});
 					}
 				}
 				it++;

--- a/game/state/gamestate_serialize.xml
+++ b/game/state/gamestate_serialize.xml
@@ -284,6 +284,8 @@
 		<member>requireGoal</member>
 		<member>free</member>
 		<member>item</member>
+		<member>velocityXY</member>
+		<member>velocityZ</member>
 		<member>timeToSnooze</member>
 		<member>timeUnits</member>
 		<member>bodyState</member>
@@ -514,6 +516,8 @@
 		<member>item</member>
 		<member>position</member>
 		<member>velocity</member>
+		<member>bounced</member>
+		<member>supported</member>
 	</object>
 	<object>
 		<name>BattleMapPart</name>

--- a/game/state/rules/aequipment_rules.cpp
+++ b/game/state/rules/aequipment_rules.cpp
@@ -56,6 +56,7 @@ sp<EquipmentSet> StateObject<EquipmentSet>::get(const GameState &state, const US
 	return it->second;
 }
 
+
 StateRef<AEquipmentType> AEquipment::getPayloadType()
 {
 	if (type->type == AEquipmentType::Type::Weapon && type->ammo_types.size() > 0)

--- a/game/state/tileview/collision.cpp
+++ b/game/state/tileview/collision.cpp
@@ -11,7 +11,7 @@ namespace OpenApoc
 {
 
 Collision TileMap::findCollision(Vec3<float> lineSegmentStart, Vec3<float> lineSegmentEnd,
-                                 std::set<TileObject::Type> validTypes, bool check_full_path) const
+	const std::set<TileObject::Type> validTypes, const sp<TileObject>  owner, bool check_full_path) const
 {
 	bool type_checking = validTypes.size() > 0;
 	Collision c;
@@ -23,8 +23,11 @@ Collision TileMap::findCollision(Vec3<float> lineSegmentStart, Vec3<float> lineS
 	LineSegment<int, true> line{lineSegmentStartVoxel, lineSegmentEndVoxel};
 	// "point" is thee corrdinate measured in voxel scale units, meaning,
 	// voxel point coordinate within map
+	//LogWarning("Collision from %f %f %f to %f %f %f", lineSegmentStart.x, lineSegmentStart.y, lineSegmentStart.z ,lineSegmentEnd.x, lineSegmentEnd.y, lineSegmentEnd.z);
+	//LogWarning("Voxel from %d %d %d to %d %d %d", lineSegmentStartVoxel.x, lineSegmentStartVoxel.y, lineSegmentStartVoxel.z, lineSegmentEndVoxel.x, lineSegmentEndVoxel.y, lineSegmentEndVoxel.z);
 	for (auto &point : line)
 	{
+//		LogWarning("Checking point %d %d %d", point.x, point.y, point.z);
 		auto tile = point / tileSize;
 		if (tile.x < 0 || tile.x >= size.x || tile.y < 0 || tile.y >= size.y || tile.z < 0 ||
 		    tile.z >= size.z)
@@ -38,6 +41,8 @@ Collision TileMap::findCollision(Vec3<float> lineSegmentStart, Vec3<float> lineS
 		const Tile *t = this->getTile(tile);
 		for (auto &obj : t->intersectingObjects)
 		{
+			if (obj == owner)
+				continue;
 			if (!obj->hasVoxelMap())
 				continue;
 			if (type_checking && validTypes.find(obj->type) == validTypes.end())
@@ -55,7 +60,6 @@ Collision TileMap::findCollision(Vec3<float> lineSegmentStart, Vec3<float> lineS
 				continue;
 			// coordinate of the voxel within map
 			Vec3<int> voxelPosWithinMap = voxelPos % tileSize;
-			// FIXME: Get appropriate voxel map for the position and facing of the object
 			if (voxelMap->getBit(voxelPosWithinMap))
 			{
 				c.obj = obj;

--- a/game/state/tileview/tile.cpp
+++ b/game/state/tileview/tile.cpp
@@ -434,8 +434,34 @@ sp<TileObjectBattleUnit> Tile::getUnitIfPresent() { return firstUnitPresent; }
 
 sp<TileObjectBattleUnit> Tile::getUnitIfPresent(bool onlyConscious, bool mustOccupy,
                                                 bool mustBeStatic,
-                                                sp<TileObjectBattleUnit> exceptThis, bool onlyLarge)
+                                                sp<TileObjectBattleUnit> exceptThis, bool onlyLarge, bool checkLargeSpace)
 {
+	if (checkLargeSpace)
+	{
+		for (int x = -1; x >= 0; x++)
+		{
+			for (int y = -1; y >= 0;y++)
+			{
+				for (int z = 0; z <= 1;z++)
+				{
+					if (x == 0 && y == 0 && z == 0)
+					{
+						continue;
+					}
+					if (position.x + x < 0 || position.y + y < 0 || position.z + z >= map.size.z)
+					{
+						continue;
+					}
+					auto u = map.getTile(position.x + x, position.y + y, position.z + z)->getUnitIfPresent(onlyConscious, mustOccupy, mustBeStatic, exceptThis, onlyLarge, false);
+					if (u)
+					{
+						return u;
+					}
+				}
+			}
+		}
+	}
+
 	for (auto o : intersectingObjects)
 	{
 		if (o->getType() == TileObject::Type::Unit)
@@ -454,6 +480,48 @@ sp<TileObjectBattleUnit> Tile::getUnitIfPresent(bool onlyConscious, bool mustOcc
 		}
 	}
 	return nullptr;
+}
+
+std::list<sp<BattleItem>> Tile::getItems()
+{
+	std::list<sp<BattleItem>> result;
+	for (auto o : ownedObjects)
+	{
+		if (o->getType() == TileObject::Type::Item)
+		{
+			auto item = std::static_pointer_cast<TileObjectBattleItem>(o)->getItem();
+			if (item->supported)
+			{
+				result.push_back(item);
+			}
+		}
+	}
+	for (int x = -1; x <= 1; x++)
+	{
+		for (int y = -1; y <= 1;y++)
+		{
+			if (x == 0 && y == 0)
+			{
+				continue;
+			}
+			auto pos = Vec3<int>{ position.x + x, position.y + y, position.z };
+			if (pos.x < 0 || pos.x >= map.size.x || pos.y < 0 || pos.y >= map.size.y)
+				continue;
+			auto t = map.getTile(pos);
+			for (auto o : t->ownedObjects)
+			{
+				if (o->getType() == TileObject::Type::Item)
+				{
+					auto item = std::static_pointer_cast<TileObjectBattleItem>(o)->getItem();
+					if (item->supported)
+					{
+						result.push_back(item);
+					}
+				}
+			}
+		}
+	}
+	return result;
 }
 
 void TileMap::addObjectToMap(sp<Projectile> projectile)
@@ -625,7 +693,7 @@ sp<Image> TileMap::dumpVoxelView(const Rect<int> viewRect, const TileTransform &
 			auto topPos = transform.screenToTileCoords(Vec2<float>{x, y} + offset, maxZ - 0.01f);
 			auto bottomPos = transform.screenToTileCoords(Vec2<float>{x, y} + offset, 0.0f);
 
-			auto collision = this->findCollision(topPos, bottomPos, {}, true);
+			auto collision = this->findCollision(topPos, bottomPos, {}, nullptr, true);
 			if (collision)
 			{
 				if (objectColours.find(collision.obj) == objectColours.end())

--- a/game/state/tileview/tile.h
+++ b/game/state/tileview/tile.h
@@ -11,7 +11,6 @@
 #define TICK_SCALE (36)
 #define VELOCITY_SCALE_CITY (Vec3<float>{32, 32, 16})
 #define VELOCITY_SCALE_BATTLE (Vec3<float>{24, 24, 20})
-#define FALLING_ACCELERATION 6
 
 // This enables showing tiles that were tried by the last pathfinding attempt
 // Is only displayed in battlescape right now
@@ -80,7 +79,9 @@ class Tile
 	sp<TileObjectBattleUnit> getUnitIfPresent(bool onlyConscious, bool mustOccupy = false,
 	                                          bool mustBeStatic = false,
 	                                          sp<TileObjectBattleUnit> exceptThis = nullptr,
-	                                          bool onlyLarge = false);
+	                                          bool onlyLarge = false, bool checkLargeSpace = false);
+	// Returns items that can be collected by standing in this tile)
+	std::list<sp<BattleItem>> getItems();
 	// Returns resting position for items and units in the tile
 	Vec3<float> getRestingPosition(bool large = false);
 	// Returns the object that provides support (resting position) for items
@@ -220,8 +221,9 @@ class TileMap
 										  float maxCost = 0.0f);
 
 	Collision findCollision(Vec3<float> lineSegmentStart, Vec3<float> lineSegmentEnd,
-	                        std::set<TileObject::Type> validTypes = {},
-	                        bool check_full_path = false) const;
+					const std::set<TileObject::Type> validTypes = {},
+					const sp<TileObject> owner = nullptr,
+		bool check_full_path = false) const;
 
 	void addObjectToMap(sp<Projectile>);
 	void addObjectToMap(sp<Vehicle>);

--- a/game/state/tileview/tileobject_battleitem.cpp
+++ b/game/state/tileview/tileobject_battleitem.cpp
@@ -53,6 +53,17 @@ TileObjectBattleItem::TileObjectBattleItem(TileMap &map, sp<BattleItem> item)
 {
 }
 
+sp<BattleItem> TileObjectBattleItem::getItem()
+{
+	auto i = item.lock();
+	if (!i)
+	{
+		LogError("Item disappeared");
+		return nullptr;
+	}
+	return i;
+}
+
 Vec3<float> TileObjectBattleItem::getPosition() const
 {
 	auto p = this->item.lock();

--- a/game/state/tileview/tileobject_battleitem.h
+++ b/game/state/tileview/tileobject_battleitem.h
@@ -13,6 +13,7 @@ class TileObjectBattleItem : public TileObject
 	void draw(Renderer &r, TileTransform &transform, Vec2<float> screenPosition, TileViewMode mode,
 	          int) override;
 	~TileObjectBattleItem() override;
+	sp<BattleItem> getItem();
 	Vec3<float> getPosition() const override;
 	Vec3<float> getCenterOffset() const override { return {0.0f, 0.0f, bounds_div_2.z}; }
 

--- a/game/state/tileview/tileobject_battleunit.cpp
+++ b/game/state/tileview/tileobject_battleunit.cpp
@@ -195,7 +195,8 @@ void TileObjectBattleUnit::setPosition(Vec3<float> newPosition)
 	// Set appropriate bounds for the unit
 	auto size = std::max(u->agent->type->bodyType->size[u->current_body_state][u->facing],
 	                     u->agent->type->bodyType->size[u->target_body_state][u->facing]);
-	setBounds({size.x, size.y, size.z});
+	auto maxHeight = std::max(u->agent->type->bodyType->height[u->current_body_state], u->agent->type->bodyType->height[u->target_body_state]);
+	setBounds({size.x, size.y, (float)maxHeight / 40.0f});
 	// It would be appropriate to set bounds based on unit height, like this:
 	//   setBounds({ size.x, size.y, (float)u->agent->type->bodyType->maxHeight / 40.0f });
 	// However, this requires re-aligning unit sprites according to their height,
@@ -203,7 +204,7 @@ void TileObjectBattleUnit::setPosition(Vec3<float> newPosition)
 	// Therefore, it's much easier to just leave it this way
 	if (u->isLarge())
 	{
-		centerOffset = {0.0f, 0.0f, bounds_div_2.z};
+		centerOffset = {0.0f, 0.0f, 1.0f};
 	}
 	else // if small
 	{
@@ -211,11 +212,11 @@ void TileObjectBattleUnit::setPosition(Vec3<float> newPosition)
 		    u->target_body_state == AgentType::BodyState::Prone)
 		{
 			centerOffset = {-u->facing.x * bounds.x / 4.0f, -u->facing.y * bounds.y / 4.0f,
-			                bounds_div_2.z};
+			                0.5f};
 		}
 		else
 		{
-			centerOffset = {0.0f, 0.0f, bounds_div_2.z};
+			centerOffset = {0.0f, 0.0f, 0.5f};
 		}
 	}
 

--- a/game/ui/battle/battleview.h
+++ b/game/ui/battle/battleview.h
@@ -27,10 +27,15 @@ enum class BattleSelectionState
 	NormalAlt,
 	NormalCtrl,
 	NormalCtrlAlt,
-	Fire,
+	PsiLeft,
+	PsiRight,
+	FireAny, 
+	FireLeft,
+	FireRight,
 	ThrowLeft,
 	ThrowRight,
-	// Psi,
+	TeleportLeft,
+	TeleportRight,
 };
 
 // All the info required to draw a single item info chunk, kept together to make it easier to
@@ -72,6 +77,7 @@ class BattleView : public BattleTileView
 	bool colorForward = true;
 	int colorCurrent = 0;
 	sp<Palette> palette;
+	std::vector<sp<Palette>> modPalette;
 
 	BattleSelectionState selectionState;
 	bool modifierLShift = false;
@@ -82,6 +88,7 @@ class BattleView : public BattleTileView
 	bool modifierRCtrl = false;
 	int leftThrowDelay = 0;
 	int rightThrowDelay = 0;
+	int actionImpossibleDelay = 0;
 
 	void updateSelectionMode();
 	void updateSelectedUnits();
@@ -103,6 +110,7 @@ class BattleView : public BattleTileView
 	void orderTurn(Vec3<int> target);
 	void orderDrop(bool right);
 	void orderThrow(Vec3<int> target, bool right);
+	void orderTeleport(Vec3<int> target, bool right);
 	void orderSelect(sp<BattleUnit> u, bool inverse = false, bool additive = false);
 	void attemptToClearCurrentOrders(sp<BattleUnit> u, bool overrideBodyStateChange = false);
 	bool canEmplaceTurnInFront(sp<BattleUnit> u);
@@ -114,6 +122,7 @@ class BattleView : public BattleTileView
 	void resume() override;
 	void update() override;
 	void render() override;
+	void finish() override;
 	void eventOccurred(Event *e) override;
 
 	void setUpdateSpeed(BattleUpdateSpeed updateSpeed);

--- a/game/ui/tileview/battletileview.h
+++ b/game/ui/tileview/battletileview.h
@@ -1,12 +1,12 @@
 #pragma once
 #include "framework/framework.h"
 #include "game/ui/tileview/tileview.h"
-#include "game/state/battle/battle.h"
 
 namespace OpenApoc
 {
 
 class TileObjectBattleUnit;
+class Battle;
 
 class BattleTileView : public TileView
 {
@@ -24,7 +24,7 @@ class BattleTileView : public TileView
   private:
 	int currentZLevel;
 	LayerDrawingMode layerDrawingMode;
-	Battle::Mode battleMode;
+	sp<Battle> battle;
 
 	sp<Image> selectedTileEmptyImageBack;
 	sp<Image> selectedTileEmptyImageFront;
@@ -54,7 +54,7 @@ class BattleTileView : public TileView
 	
   public:
 	BattleTileView(TileMap &map, Vec3<int> isoTileSize, Vec2<int> stratTileSize,
-	               TileViewMode initialMode, int currentZLevel, Vec3<float> screenCenterTile, Battle::Mode battleMode);
+	               TileViewMode initialMode, int currentZLevel, Vec3<float> screenCenterTile, sp<Battle> battle);
 	~BattleTileView() override;
 
 	std::list<sp<BattleUnit>> selectedUnits;

--- a/library/line.h
+++ b/library/line.h
@@ -10,10 +10,15 @@ template <typename T, bool conservative> class LineSegment
   public:
 	Vec3<T> startPoint;
 	Vec3<T> endPoint;
+	Vec3<T> inc;
 	T increment;
 	LineSegment(Vec3<T> start, Vec3<T> end, T increment = 1)
 	    : startPoint(start), endPoint(end), increment(increment)
 	{
+		Vec3<T> d = endPoint - startPoint;
+		inc.x = (d.x < static_cast<T>(0)) ? -increment : increment;
+		inc.y = (d.y < static_cast<T>(0)) ? -increment : increment;
+		inc.z = (d.z < static_cast<T>(0)) ? -increment : increment;
 	}
 	LineSegmentIterator<T, conservative> begin();
 	LineSegmentIterator<T, conservative> end();
@@ -25,9 +30,9 @@ class LineSegmentIterator : public std::iterator<std::forward_iterator_tag, Vec3
   private:
 	Vec3<T> point;
 	Vec3<T> err;
-	Vec3<T> inc;
 	Vec3<T> step;
 	Vec3<T> d2;
+	Vec3<T> inc;
 	T dstep2;
 
 	LineSegment<T, conservative> &line;
@@ -38,10 +43,7 @@ class LineSegmentIterator : public std::iterator<std::forward_iterator_tag, Vec3
 		err = {static_cast<T>(0), static_cast<T>(0), static_cast<T>(0)};
 		step = {static_cast<T>(0), static_cast<T>(0), static_cast<T>(0)};
 		Vec3<T> d = l.endPoint - l.startPoint;
-		inc.x = (d.x < static_cast<T>(0)) ? -l.increment : l.increment;
-		inc.y = (d.y < static_cast<T>(0)) ? -l.increment : l.increment;
-		inc.z = (d.z < static_cast<T>(0)) ? -l.increment : l.increment;
-
+		inc = l.inc;
 		Vec3<T> absd = glm::abs(d);
 		d2 = absd * static_cast<T>(2);
 		if (absd.x >= absd.y && absd.x >= absd.z)
@@ -131,7 +133,7 @@ LineSegmentIterator<T, conservative> LineSegment<T, conservative>::begin()
 template <typename T, bool conservative>
 LineSegmentIterator<T, conservative> LineSegment<T, conservative>::end()
 {
-	return LineSegmentIterator<T, conservative>(this->endPoint + Vec3<T>{1, 1, 1}, *this);
+	return LineSegmentIterator<T, conservative>(this->endPoint + this->inc, *this);
 }
 
 } // nammespace OpenApoc

--- a/tools/extractors/extract_battle_shared_resources.cpp
+++ b/tools/extractors/extract_battle_shared_resources.cpp
@@ -57,7 +57,7 @@ void InitialGameStateExtractor::extractSharedBattleResources(GameState &state)
 	state.battle_common_sample_list->brainsuckerHatch =
 	    fw().data->loadSample("RAWSOUND:xcom3/rawsound/extra/brhatch.raw:22050");
 	state.battle_common_sample_list->teleport =
-	    fw().data->loadSample("RAWSOUND:xcom3/rawsound/tactical/explosions/teleport.raw:22050");
+	    fw().data->loadSample("RAWSOUND:xcom3/rawsound/tactical/explosns/teleport.raw:22050");
 
 	UString sfx_name = "";
 	for (int i = 1; i <= 8; i++)

--- a/tools/extractors/extract_unit_animation_pack_unit.cpp
+++ b/tools/extractors/extract_unit_animation_pack_unit.cpp
@@ -519,17 +519,17 @@ void InitialGameStateExtractor::extractAnimationPackUnit(sp<BattleUnitAnimationP
 			[AgentType::HandState::AtEase][AgentType::MovementState::None]
 			[AgentType::BodyState::Throwing][AgentType::BodyState::Standing]
 			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 41, { x, y }, 100, 5, false, false, true, { 0,0 }, { 0,0 }, false, 5);
+			getAnimationEntry(dataAD, dataUA, dataUF, 41, { x, y }, 100, 5, false, false, true, { 0,0 }, { 0,0 }, false, 3);
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
 			[AgentType::HandState::AtEase][AgentType::MovementState::None]
 			[AgentType::BodyState::Throwing][AgentType::BodyState::Standing]
 			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 41, { x, y }, 100, 5, false, false, true, { 0,0 }, { 0,0 }, false, 5);
+			getAnimationEntry(dataAD, dataUA, dataUF, 41, { x, y }, 100, 5, false, false, true, { 0,0 }, { 0,0 }, false, 3);
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
 			[AgentType::HandState::AtEase][AgentType::MovementState::None]
 			[AgentType::BodyState::Throwing][AgentType::BodyState::Standing]
 			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 41, { x, y }, 100, 5, false, false, true, { 0,0 }, { 0,0 }, false, 5);
+			getAnimationEntry(dataAD, dataUA, dataUF, 41, { x, y }, 100, 5, false, false, true, { 0,0 }, { 0,0 }, false, 3);
 	}
 
 	// Hand state change animation


### PR DESCRIPTION
- fixed collision bug (end iterator was always endpoint +1,1,1
regardless of line's direction, which made collisions skip last point
when going negative on the axes)
- item throwing trajectories more closely resemble vanilla
- item throwing limited by strength, and item weight
- item throwing calcualtes trajectories and ensures thrown object will
arrive at destination
- more efficient rendering in battleview (do not recreate pallets every
time)
- implemented teleporters (click mouse wheel to use for now, while
soldiers do now own them)
- implemented cursor change in battlescape
- implemented picking up first item from the ground by using "drop"
button near hand slot