### PR TITLE
Projectile improvements and firing weapons in battlescape!

### DIFF
--- a/data/difficulty1_patched/checksum.xml
+++ b/data/difficulty1_patched/checksum.xml
@@ -2,12 +2,12 @@
 <checksums>
   <checksum SHA1="de1732555e585509f8077f0c8e03c697f3d20945">gamestate.xml</checksum>
   <checksum SHA1="e82ad81e87952471fc9a77dfdaf5c7de0b73340b">gamestate/agent_body_types.xml</checksum>
-  <checksum SHA1="79a8ad7d8df48a99dd5332d9c412ab6da8d9c2e3">gamestate/agent_equipment.xml</checksum>
+  <checksum SHA1="1cb75ee151d485e8f39310cd9139bc04a1d2ba74">gamestate/agent_equipment.xml</checksum>
   <checksum SHA1="db87a07c2ad3fe43a082e3143408dc3fd29ee9ff">gamestate/agent_equipment_layouts.xml</checksum>
   <checksum SHA1="282e2b08cda4a9a7094fb16355bd5e58cdc2a224">gamestate/agent_generator.xml</checksum>
   <checksum SHA1="665676441df08bedc9cdd1dec8854d5b99a8ed4f">gamestate/agent_types.xml</checksum>
   <checksum SHA1="0b1fc22224d3d4d266780fe20b1db95ee052bba0">gamestate/base_layouts.xml</checksum>
-  <checksum SHA1="23e3874d1ed51670e14c492e0ed06b374372fbaf">gamestate/battle_common_image_list.xml</checksum>
+  <checksum SHA1="06d9d5ee8bcce6c690cefe0cf21fc96c16896f11">gamestate/battle_common_image_list.xml</checksum>
   <checksum SHA1="5fbc9dc088736f547d742fa3ff3da34dc35e1941">gamestate/battle_common_sample_list.xml</checksum>
   <checksum SHA1="dcebd55d2b40ea7b7c117ce16ee71ab23be4e4ef">gamestate/battle_maps.xml</checksum>
   <checksum SHA1="09a0229c616b482ad6f16bdf5f90d879e648fb62">gamestate/battle_maps/BATTLEMAP_01senate.xml</checksum>

--- a/data/difficulty1_patched/checksum.xml
+++ b/data/difficulty1_patched/checksum.xml
@@ -2,7 +2,7 @@
 <checksums>
   <checksum SHA1="de1732555e585509f8077f0c8e03c697f3d20945">gamestate.xml</checksum>
   <checksum SHA1="e82ad81e87952471fc9a77dfdaf5c7de0b73340b">gamestate/agent_body_types.xml</checksum>
-  <checksum SHA1="1cb75ee151d485e8f39310cd9139bc04a1d2ba74">gamestate/agent_equipment.xml</checksum>
+  <checksum SHA1="0c98b18d8eca57f5f1e83f4c9ea28d0967e74bb5">gamestate/agent_equipment.xml</checksum>
   <checksum SHA1="db87a07c2ad3fe43a082e3143408dc3fd29ee9ff">gamestate/agent_equipment_layouts.xml</checksum>
   <checksum SHA1="282e2b08cda4a9a7094fb16355bd5e58cdc2a224">gamestate/agent_generator.xml</checksum>
   <checksum SHA1="665676441df08bedc9cdd1dec8854d5b99a8ed4f">gamestate/agent_types.xml</checksum>

--- a/data/difficulty1_patched/gamestate/agent_equipment.xml
+++ b/data/difficulty1_patched/gamestate/agent_equipment.xml
@@ -120,6 +120,7 @@
         <tail_size>26</tail_size>
         <turn_rate>40</turn_rate>
         <range>180</range>
+        <ttl>440</ttl>
         <explosion_graphic>28</explosion_graphic>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
@@ -178,6 +179,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_ANTI-ALIEN_GAS</damage_type>
         <explosion_depletion_rate>10</explosion_depletion_rate>
       </sp>
@@ -253,6 +255,7 @@
         <fire_delay>34</fire_delay>
         <tail_size>31</tail_size>
         <range>900</range>
+        <ttl>2700</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
@@ -328,6 +331,7 @@
         <fire_delay>34</fire_delay>
         <tail_size>31</tail_size>
         <range>900</range>
+        <ttl>2700</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>4</explosion_depletion_rate>
       </sp>
@@ -403,6 +407,7 @@
         <fire_delay>34</fire_delay>
         <tail_size>31</tail_size>
         <range>900</range>
+        <ttl>2700</ttl>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -463,6 +468,7 @@
         <guided>true</guided>
         <turn_rate>30</turn_rate>
         <range>400</range>
+        <ttl>1800</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <trigger_type>Boomeroid</trigger_type>
         <explosion_depletion_rate>9</explosion_depletion_rate>
@@ -575,6 +581,7 @@
         <fire_delay>64</fire_delay>
         <tail_size>34</tail_size>
         <range>500</range>
+        <ttl>1400</ttl>
         <damage_type>DAMAGETYPE_BRAINSUCKER</damage_type>
       </sp>
     </value>
@@ -653,6 +660,7 @@
         <fire_delay>40</fire_delay>
         <tail_size>35</tail_size>
         <range>1000</range>
+        <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
@@ -797,6 +805,7 @@
         <guided>true</guided>
         <turn_rate>25</turn_rate>
         <range>1400</range>
+        <ttl>4200</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>14</explosion_depletion_rate>
       </sp>
@@ -889,6 +898,7 @@
         <fire_delay>32</fire_delay>
         <tail_size>17</tail_size>
         <range>800</range>
+        <ttl>2400</ttl>
         <explosion_graphic>24</explosion_graphic>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
@@ -998,6 +1008,7 @@
         <fire_delay>40</fire_delay>
         <tail_size>35</tail_size>
         <range>1000</range>
+        <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
@@ -1112,6 +1123,7 @@
         <guided>true</guided>
         <turn_rate>18</turn_rate>
         <range>1200</range>
+        <ttl>3600</ttl>
         <explosion_graphic>28</explosion_graphic>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
@@ -1227,6 +1239,7 @@
         <guided>true</guided>
         <turn_rate>20</turn_rate>
         <range>1200</range>
+        <ttl>3600</ttl>
         <damage_type>DAMAGETYPE_ANTI-ALIEN_GAS</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1310,6 +1323,7 @@
         <guided>true</guided>
         <turn_rate>20</turn_rate>
         <range>1200</range>
+        <ttl>3600</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1393,6 +1407,7 @@
         <guided>true</guided>
         <turn_rate>20</turn_rate>
         <range>1200</range>
+        <ttl>3600</ttl>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1460,6 +1475,7 @@
         <tail_size>26</tail_size>
         <turn_rate>40</turn_rate>
         <range>50</range>
+        <ttl>120</ttl>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
     </value>
@@ -1517,6 +1533,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>12</explosion_depletion_rate>
       </sp>
@@ -1679,6 +1696,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>15</explosion_depletion_rate>
       </sp>
@@ -1820,6 +1838,7 @@
         <fire_delay>12</fire_delay>
         <tail_size>25</tail_size>
         <range>900</range>
+        <ttl>2700</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
@@ -1942,6 +1961,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <trigger_type>Proximity</trigger_type>
         <explosion_depletion_rate>9</explosion_depletion_rate>
@@ -2068,6 +2088,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>7</explosion_depletion_rate>
       </sp>
@@ -2251,6 +2272,7 @@
         <fire_delay>42</fire_delay>
         <tail_size>36</tail_size>
         <range>1200</range>
+        <ttl>3600</ttl>
         <explosion_graphic>22</explosion_graphic>
         <damage_type>DAMAGETYPE_LASER_BEAM</damage_type>
       </sp>
@@ -2374,6 +2396,7 @@
         <fire_delay>18</fire_delay>
         <tail_size>16</tail_size>
         <range>700</range>
+        <ttl>2200</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
@@ -2558,6 +2581,7 @@
         <fire_delay>30</fire_delay>
         <tail_size>36</tail_size>
         <range>900</range>
+        <ttl>2700</ttl>
         <explosion_graphic>23</explosion_graphic>
         <damage_type>DAMAGETYPE_PLASMA</damage_type>
       </sp>
@@ -2652,6 +2676,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_SMOKE</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -2712,6 +2737,7 @@
         <fire_delay>44</fire_delay>
         <tail_size>16</tail_size>
         <range>100</range>
+        <ttl>240</ttl>
         <explosion_graphic>26</explosion_graphic>
         <damage_type>DAMAGETYPE_STUN</damage_type>
       </sp>
@@ -2770,6 +2796,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_STUN_GAS</damage_type>
         <explosion_depletion_rate>12</explosion_depletion_rate>
       </sp>
@@ -2844,6 +2871,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>35</tail_size>
         <range>1000</range>
+        <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
@@ -2922,6 +2950,7 @@
         <guided>true</guided>
         <turn_rate>30</turn_rate>
         <range>1400</range>
+        <ttl>4200</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>13</explosion_depletion_rate>
       </sp>
@@ -3063,6 +3092,7 @@
         <guided>true</guided>
         <turn_rate>35</turn_rate>
         <range>600</range>
+        <ttl>1800</ttl>
         <damage_type>DAMAGETYPE_ANTI-ALIEN_GAS</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3142,6 +3172,7 @@
         <guided>true</guided>
         <turn_rate>35</turn_rate>
         <range>600</range>
+        <ttl>1800</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3221,6 +3252,7 @@
         <guided>true</guided>
         <turn_rate>35</turn_rate>
         <range>600</range>
+        <ttl>1800</ttl>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3358,6 +3390,7 @@
         <tail_size>34</tail_size>
         <turn_rate>40</turn_rate>
         <range>260</range>
+        <ttl>600</ttl>
         <explosion_graphic>28</explosion_graphic>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
@@ -3510,6 +3543,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1200</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>22</explosion_depletion_rate>
       </sp>
@@ -3569,6 +3603,7 @@
         <fire_delay>35</fire_delay>
         <tail_size>16</tail_size>
         <range>40</range>
+        <ttl>100</ttl>
         <explosion_graphic>23</explosion_graphic>
         <damage_type>DAMAGETYPE_PLASMA</damage_type>
       </sp>
@@ -3627,6 +3662,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_PSIONIC_BLAST</damage_type>
         <explosion_depletion_rate>10</explosion_depletion_rate>
       </sp>
@@ -3760,6 +3796,7 @@
         <tail_size>34</tail_size>
         <turn_rate>40</turn_rate>
         <range>900</range>
+        <ttl>2200</ttl>
         <explosion_graphic>28</explosion_graphic>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
@@ -3835,6 +3872,7 @@
         <tail_size>34</tail_size>
         <turn_rate>40</turn_rate>
         <range>384</range>
+        <ttl>900</ttl>
         <explosion_graphic>28</explosion_graphic>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
@@ -3927,6 +3965,7 @@
         <fire_delay>8</fire_delay>
         <tail_size>16</tail_size>
         <range>800</range>
+        <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_TOXIN_A</damage_type>
       </sp>
@@ -3988,6 +4027,7 @@
         <fire_delay>8</fire_delay>
         <tail_size>16</tail_size>
         <range>800</range>
+        <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_TOXIN_B</damage_type>
       </sp>
@@ -4049,6 +4089,7 @@
         <fire_delay>8</fire_delay>
         <tail_size>16</tail_size>
         <range>800</range>
+        <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_TOXIN_C</damage_type>
       </sp>
@@ -4140,6 +4181,7 @@
         <fire_delay>36</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1200</ttl>
         <damage_type>DAMAGETYPE_SMOKE</damage_type>
       </sp>
     </value>
@@ -4197,6 +4239,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>300</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>19</explosion_depletion_rate>
       </sp>

--- a/data/difficulty1_patched/gamestate/agent_equipment.xml
+++ b/data/difficulty1_patched/gamestate/agent_equipment.xml
@@ -257,6 +257,8 @@
         <range>900</range>
         <ttl>2700</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/megcanon.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet3.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
     </value>
@@ -332,6 +334,8 @@
         <tail_size>31</tail_size>
         <range>900</range>
         <ttl>2700</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/megcanon.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet3.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>4</explosion_depletion_rate>
       </sp>
@@ -408,6 +412,8 @@
         <tail_size>31</tail_size>
         <range>900</range>
         <ttl>2700</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/megcanon.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet3.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -582,6 +588,7 @@
         <tail_size>34</tail_size>
         <range>500</range>
         <ttl>1400</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/powers.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_BRAINSUCKER</damage_type>
       </sp>
     </value>
@@ -662,6 +669,7 @@
         <range>1000</range>
         <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/dcannon1.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
     </value>
@@ -806,6 +814,7 @@
         <turn_rate>25</turn_rate>
         <range>1400</range>
         <ttl>4200</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/dimnmisl.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>14</explosion_depletion_rate>
       </sp>
@@ -900,6 +909,7 @@
         <range>800</range>
         <ttl>2400</ttl>
         <explosion_graphic>24</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/disruptr.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
     </value>
@@ -1010,6 +1020,7 @@
         <range>1000</range>
         <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/dcannon1.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
     </value>
@@ -1125,6 +1136,7 @@
         <range>1200</range>
         <ttl>3600</ttl>
         <explosion_graphic>28</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/entropy.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
     </value>
@@ -1240,6 +1252,7 @@
         <turn_rate>20</turn_rate>
         <range>1200</range>
         <ttl>3600</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec1.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ANTI-ALIEN_GAS</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1324,6 +1337,7 @@
         <turn_rate>20</turn_rate>
         <range>1200</range>
         <ttl>3600</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec1.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1408,6 +1422,7 @@
         <turn_rate>20</turn_rate>
         <range>1200</range>
         <ttl>3600</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec1.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1476,6 +1491,7 @@
         <turn_rate>40</turn_rate>
         <range>50</range>
         <ttl>120</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/aliens/attacks/wrmattak.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
     </value>
@@ -1840,6 +1856,8 @@
         <range>900</range>
         <ttl>2700</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet1.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet2.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
     </value>
@@ -2274,6 +2292,8 @@
         <range>1200</range>
         <ttl>3600</ttl>
         <explosion_graphic>22</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/sniper.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/zaphit.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_LASER_BEAM</damage_type>
       </sp>
     </value>
@@ -2398,6 +2418,8 @@
         <range>700</range>
         <ttl>2200</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet1.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet2.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
     </value>
@@ -2583,6 +2605,8 @@
         <range>900</range>
         <ttl>2700</ttl>
         <explosion_graphic>23</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/megapol.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/meghit.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_PLASMA</damage_type>
       </sp>
     </value>
@@ -2739,6 +2763,7 @@
         <range>100</range>
         <ttl>240</ttl>
         <explosion_graphic>26</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/megastun.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_STUN</damage_type>
       </sp>
     </value>
@@ -2873,6 +2898,7 @@
         <range>1000</range>
         <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/disruptr.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
     </value>
@@ -2951,6 +2977,7 @@
         <turn_rate>30</turn_rate>
         <range>1400</range>
         <ttl>4200</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/extra/tronlaun.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>13</explosion_depletion_rate>
       </sp>
@@ -3093,6 +3120,7 @@
         <turn_rate>35</turn_rate>
         <range>600</range>
         <ttl>1800</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec2.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ANTI-ALIEN_GAS</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3173,6 +3201,7 @@
         <turn_rate>35</turn_rate>
         <range>600</range>
         <ttl>1800</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec2.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3253,6 +3282,7 @@
         <turn_rate>35</turn_rate>
         <range>600</range>
         <ttl>1800</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec2.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3392,6 +3422,7 @@
         <range>260</range>
         <ttl>600</ttl>
         <explosion_graphic>28</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/aliens/attacks/wormspit.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
     </value>
@@ -3605,6 +3636,7 @@
         <range>40</range>
         <ttl>100</ttl>
         <explosion_graphic>23</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/powers.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_PLASMA</damage_type>
       </sp>
     </value>
@@ -3798,6 +3830,7 @@
         <range>900</range>
         <ttl>2200</ttl>
         <explosion_graphic>28</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/aliens/attacks/queenwhp.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
     </value>
@@ -3874,6 +3907,7 @@
         <range>384</range>
         <ttl>900</ttl>
         <explosion_graphic>28</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/aliens/attacks/spitter.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
     </value>
@@ -3967,6 +4001,7 @@
         <range>800</range>
         <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/toxigun.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_TOXIN_A</damage_type>
       </sp>
     </value>
@@ -4029,6 +4064,7 @@
         <range>800</range>
         <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/toxigun.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_TOXIN_B</damage_type>
       </sp>
     </value>
@@ -4091,6 +4127,7 @@
         <range>800</range>
         <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/toxigun.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_TOXIN_C</damage_type>
       </sp>
     </value>
@@ -4182,6 +4219,8 @@
         <tail_size>16</tail_size>
         <range>400</range>
         <ttl>1200</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/trakgun.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/trakhit.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_SMOKE</damage_type>
       </sp>
     </value>

--- a/data/difficulty1_patched/gamestate/battle_common_image_list.xml
+++ b/data/difficulty1_patched/gamestate/battle_common_image_list.xml
@@ -488,5 +488,11 @@
       <entry>PCKSTRAT:xcom3/tacdata/stratico.pck:xcom3/tacdata/stratico.tab:483</entry>
     </strategyImages>
     <loadingImage>xcom3/ufodata/enttact.pcx</loadingImage>
+    <focusArrows>
+      <entry>PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/icons.tab:64:xcom3/tacdata/tactical.pal</entry>
+      <entry>PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/icons.tab:65:xcom3/tacdata/tactical.pal</entry>
+      <entry>PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/icons.tab:66:xcom3/tacdata/tactical.pal</entry>
+      <entry>PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/icons.tab:67:xcom3/tacdata/tactical.pal</entry>
+    </focusArrows>
   </sp>
 </battle_common_image_list>

--- a/data/difficulty2_patched/checksum.xml
+++ b/data/difficulty2_patched/checksum.xml
@@ -2,12 +2,12 @@
 <checksums>
   <checksum SHA1="de1732555e585509f8077f0c8e03c697f3d20945">gamestate.xml</checksum>
   <checksum SHA1="e82ad81e87952471fc9a77dfdaf5c7de0b73340b">gamestate/agent_body_types.xml</checksum>
-  <checksum SHA1="79a8ad7d8df48a99dd5332d9c412ab6da8d9c2e3">gamestate/agent_equipment.xml</checksum>
+  <checksum SHA1="1cb75ee151d485e8f39310cd9139bc04a1d2ba74">gamestate/agent_equipment.xml</checksum>
   <checksum SHA1="db87a07c2ad3fe43a082e3143408dc3fd29ee9ff">gamestate/agent_equipment_layouts.xml</checksum>
   <checksum SHA1="282e2b08cda4a9a7094fb16355bd5e58cdc2a224">gamestate/agent_generator.xml</checksum>
   <checksum SHA1="665676441df08bedc9cdd1dec8854d5b99a8ed4f">gamestate/agent_types.xml</checksum>
   <checksum SHA1="0b1fc22224d3d4d266780fe20b1db95ee052bba0">gamestate/base_layouts.xml</checksum>
-  <checksum SHA1="23e3874d1ed51670e14c492e0ed06b374372fbaf">gamestate/battle_common_image_list.xml</checksum>
+  <checksum SHA1="06d9d5ee8bcce6c690cefe0cf21fc96c16896f11">gamestate/battle_common_image_list.xml</checksum>
   <checksum SHA1="5fbc9dc088736f547d742fa3ff3da34dc35e1941">gamestate/battle_common_sample_list.xml</checksum>
   <checksum SHA1="dcebd55d2b40ea7b7c117ce16ee71ab23be4e4ef">gamestate/battle_maps.xml</checksum>
   <checksum SHA1="09a0229c616b482ad6f16bdf5f90d879e648fb62">gamestate/battle_maps/BATTLEMAP_01senate.xml</checksum>

--- a/data/difficulty2_patched/checksum.xml
+++ b/data/difficulty2_patched/checksum.xml
@@ -2,7 +2,7 @@
 <checksums>
   <checksum SHA1="de1732555e585509f8077f0c8e03c697f3d20945">gamestate.xml</checksum>
   <checksum SHA1="e82ad81e87952471fc9a77dfdaf5c7de0b73340b">gamestate/agent_body_types.xml</checksum>
-  <checksum SHA1="1cb75ee151d485e8f39310cd9139bc04a1d2ba74">gamestate/agent_equipment.xml</checksum>
+  <checksum SHA1="0c98b18d8eca57f5f1e83f4c9ea28d0967e74bb5">gamestate/agent_equipment.xml</checksum>
   <checksum SHA1="db87a07c2ad3fe43a082e3143408dc3fd29ee9ff">gamestate/agent_equipment_layouts.xml</checksum>
   <checksum SHA1="282e2b08cda4a9a7094fb16355bd5e58cdc2a224">gamestate/agent_generator.xml</checksum>
   <checksum SHA1="665676441df08bedc9cdd1dec8854d5b99a8ed4f">gamestate/agent_types.xml</checksum>

--- a/data/difficulty2_patched/gamestate/agent_equipment.xml
+++ b/data/difficulty2_patched/gamestate/agent_equipment.xml
@@ -120,6 +120,7 @@
         <tail_size>26</tail_size>
         <turn_rate>40</turn_rate>
         <range>180</range>
+        <ttl>440</ttl>
         <explosion_graphic>28</explosion_graphic>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
@@ -178,6 +179,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_ANTI-ALIEN_GAS</damage_type>
         <explosion_depletion_rate>10</explosion_depletion_rate>
       </sp>
@@ -253,6 +255,7 @@
         <fire_delay>34</fire_delay>
         <tail_size>31</tail_size>
         <range>900</range>
+        <ttl>2700</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
@@ -328,6 +331,7 @@
         <fire_delay>34</fire_delay>
         <tail_size>31</tail_size>
         <range>900</range>
+        <ttl>2700</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>4</explosion_depletion_rate>
       </sp>
@@ -403,6 +407,7 @@
         <fire_delay>34</fire_delay>
         <tail_size>31</tail_size>
         <range>900</range>
+        <ttl>2700</ttl>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -463,6 +468,7 @@
         <guided>true</guided>
         <turn_rate>30</turn_rate>
         <range>400</range>
+        <ttl>1800</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <trigger_type>Boomeroid</trigger_type>
         <explosion_depletion_rate>9</explosion_depletion_rate>
@@ -575,6 +581,7 @@
         <fire_delay>64</fire_delay>
         <tail_size>34</tail_size>
         <range>500</range>
+        <ttl>1400</ttl>
         <damage_type>DAMAGETYPE_BRAINSUCKER</damage_type>
       </sp>
     </value>
@@ -653,6 +660,7 @@
         <fire_delay>40</fire_delay>
         <tail_size>35</tail_size>
         <range>1000</range>
+        <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
@@ -797,6 +805,7 @@
         <guided>true</guided>
         <turn_rate>25</turn_rate>
         <range>1400</range>
+        <ttl>4200</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>14</explosion_depletion_rate>
       </sp>
@@ -889,6 +898,7 @@
         <fire_delay>32</fire_delay>
         <tail_size>17</tail_size>
         <range>800</range>
+        <ttl>2400</ttl>
         <explosion_graphic>24</explosion_graphic>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
@@ -998,6 +1008,7 @@
         <fire_delay>40</fire_delay>
         <tail_size>35</tail_size>
         <range>1000</range>
+        <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
@@ -1112,6 +1123,7 @@
         <guided>true</guided>
         <turn_rate>18</turn_rate>
         <range>1200</range>
+        <ttl>3600</ttl>
         <explosion_graphic>28</explosion_graphic>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
@@ -1227,6 +1239,7 @@
         <guided>true</guided>
         <turn_rate>20</turn_rate>
         <range>1200</range>
+        <ttl>3600</ttl>
         <damage_type>DAMAGETYPE_ANTI-ALIEN_GAS</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1310,6 +1323,7 @@
         <guided>true</guided>
         <turn_rate>20</turn_rate>
         <range>1200</range>
+        <ttl>3600</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1393,6 +1407,7 @@
         <guided>true</guided>
         <turn_rate>20</turn_rate>
         <range>1200</range>
+        <ttl>3600</ttl>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1460,6 +1475,7 @@
         <tail_size>26</tail_size>
         <turn_rate>40</turn_rate>
         <range>50</range>
+        <ttl>120</ttl>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
     </value>
@@ -1517,6 +1533,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>12</explosion_depletion_rate>
       </sp>
@@ -1679,6 +1696,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>15</explosion_depletion_rate>
       </sp>
@@ -1820,6 +1838,7 @@
         <fire_delay>12</fire_delay>
         <tail_size>25</tail_size>
         <range>900</range>
+        <ttl>2700</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
@@ -1942,6 +1961,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <trigger_type>Proximity</trigger_type>
         <explosion_depletion_rate>9</explosion_depletion_rate>
@@ -2068,6 +2088,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>7</explosion_depletion_rate>
       </sp>
@@ -2251,6 +2272,7 @@
         <fire_delay>42</fire_delay>
         <tail_size>36</tail_size>
         <range>1200</range>
+        <ttl>3600</ttl>
         <explosion_graphic>22</explosion_graphic>
         <damage_type>DAMAGETYPE_LASER_BEAM</damage_type>
       </sp>
@@ -2374,6 +2396,7 @@
         <fire_delay>18</fire_delay>
         <tail_size>16</tail_size>
         <range>700</range>
+        <ttl>2200</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
@@ -2558,6 +2581,7 @@
         <fire_delay>30</fire_delay>
         <tail_size>36</tail_size>
         <range>900</range>
+        <ttl>2700</ttl>
         <explosion_graphic>23</explosion_graphic>
         <damage_type>DAMAGETYPE_PLASMA</damage_type>
       </sp>
@@ -2652,6 +2676,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_SMOKE</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -2712,6 +2737,7 @@
         <fire_delay>44</fire_delay>
         <tail_size>16</tail_size>
         <range>100</range>
+        <ttl>240</ttl>
         <explosion_graphic>26</explosion_graphic>
         <damage_type>DAMAGETYPE_STUN</damage_type>
       </sp>
@@ -2770,6 +2796,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_STUN_GAS</damage_type>
         <explosion_depletion_rate>12</explosion_depletion_rate>
       </sp>
@@ -2844,6 +2871,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>35</tail_size>
         <range>1000</range>
+        <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
@@ -2922,6 +2950,7 @@
         <guided>true</guided>
         <turn_rate>30</turn_rate>
         <range>1400</range>
+        <ttl>4200</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>13</explosion_depletion_rate>
       </sp>
@@ -3063,6 +3092,7 @@
         <guided>true</guided>
         <turn_rate>35</turn_rate>
         <range>600</range>
+        <ttl>1800</ttl>
         <damage_type>DAMAGETYPE_ANTI-ALIEN_GAS</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3142,6 +3172,7 @@
         <guided>true</guided>
         <turn_rate>35</turn_rate>
         <range>600</range>
+        <ttl>1800</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3221,6 +3252,7 @@
         <guided>true</guided>
         <turn_rate>35</turn_rate>
         <range>600</range>
+        <ttl>1800</ttl>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3358,6 +3390,7 @@
         <tail_size>34</tail_size>
         <turn_rate>40</turn_rate>
         <range>260</range>
+        <ttl>600</ttl>
         <explosion_graphic>28</explosion_graphic>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
@@ -3510,6 +3543,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1200</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>22</explosion_depletion_rate>
       </sp>
@@ -3569,6 +3603,7 @@
         <fire_delay>35</fire_delay>
         <tail_size>16</tail_size>
         <range>40</range>
+        <ttl>100</ttl>
         <explosion_graphic>23</explosion_graphic>
         <damage_type>DAMAGETYPE_PLASMA</damage_type>
       </sp>
@@ -3627,6 +3662,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_PSIONIC_BLAST</damage_type>
         <explosion_depletion_rate>10</explosion_depletion_rate>
       </sp>
@@ -3760,6 +3796,7 @@
         <tail_size>34</tail_size>
         <turn_rate>40</turn_rate>
         <range>900</range>
+        <ttl>2200</ttl>
         <explosion_graphic>28</explosion_graphic>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
@@ -3835,6 +3872,7 @@
         <tail_size>34</tail_size>
         <turn_rate>40</turn_rate>
         <range>384</range>
+        <ttl>900</ttl>
         <explosion_graphic>28</explosion_graphic>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
@@ -3927,6 +3965,7 @@
         <fire_delay>8</fire_delay>
         <tail_size>16</tail_size>
         <range>800</range>
+        <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_TOXIN_A</damage_type>
       </sp>
@@ -3988,6 +4027,7 @@
         <fire_delay>8</fire_delay>
         <tail_size>16</tail_size>
         <range>800</range>
+        <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_TOXIN_B</damage_type>
       </sp>
@@ -4049,6 +4089,7 @@
         <fire_delay>8</fire_delay>
         <tail_size>16</tail_size>
         <range>800</range>
+        <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_TOXIN_C</damage_type>
       </sp>
@@ -4140,6 +4181,7 @@
         <fire_delay>36</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1200</ttl>
         <damage_type>DAMAGETYPE_SMOKE</damage_type>
       </sp>
     </value>
@@ -4197,6 +4239,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>300</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>19</explosion_depletion_rate>
       </sp>

--- a/data/difficulty2_patched/gamestate/agent_equipment.xml
+++ b/data/difficulty2_patched/gamestate/agent_equipment.xml
@@ -257,6 +257,8 @@
         <range>900</range>
         <ttl>2700</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/megcanon.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet3.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
     </value>
@@ -332,6 +334,8 @@
         <tail_size>31</tail_size>
         <range>900</range>
         <ttl>2700</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/megcanon.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet3.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>4</explosion_depletion_rate>
       </sp>
@@ -408,6 +412,8 @@
         <tail_size>31</tail_size>
         <range>900</range>
         <ttl>2700</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/megcanon.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet3.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -582,6 +588,7 @@
         <tail_size>34</tail_size>
         <range>500</range>
         <ttl>1400</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/powers.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_BRAINSUCKER</damage_type>
       </sp>
     </value>
@@ -662,6 +669,7 @@
         <range>1000</range>
         <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/dcannon1.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
     </value>
@@ -806,6 +814,7 @@
         <turn_rate>25</turn_rate>
         <range>1400</range>
         <ttl>4200</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/dimnmisl.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>14</explosion_depletion_rate>
       </sp>
@@ -900,6 +909,7 @@
         <range>800</range>
         <ttl>2400</ttl>
         <explosion_graphic>24</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/disruptr.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
     </value>
@@ -1010,6 +1020,7 @@
         <range>1000</range>
         <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/dcannon1.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
     </value>
@@ -1125,6 +1136,7 @@
         <range>1200</range>
         <ttl>3600</ttl>
         <explosion_graphic>28</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/entropy.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
     </value>
@@ -1240,6 +1252,7 @@
         <turn_rate>20</turn_rate>
         <range>1200</range>
         <ttl>3600</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec1.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ANTI-ALIEN_GAS</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1324,6 +1337,7 @@
         <turn_rate>20</turn_rate>
         <range>1200</range>
         <ttl>3600</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec1.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1408,6 +1422,7 @@
         <turn_rate>20</turn_rate>
         <range>1200</range>
         <ttl>3600</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec1.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1476,6 +1491,7 @@
         <turn_rate>40</turn_rate>
         <range>50</range>
         <ttl>120</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/aliens/attacks/wrmattak.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
     </value>
@@ -1840,6 +1856,8 @@
         <range>900</range>
         <ttl>2700</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet1.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet2.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
     </value>
@@ -2274,6 +2292,8 @@
         <range>1200</range>
         <ttl>3600</ttl>
         <explosion_graphic>22</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/sniper.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/zaphit.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_LASER_BEAM</damage_type>
       </sp>
     </value>
@@ -2398,6 +2418,8 @@
         <range>700</range>
         <ttl>2200</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet1.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet2.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
     </value>
@@ -2583,6 +2605,8 @@
         <range>900</range>
         <ttl>2700</ttl>
         <explosion_graphic>23</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/megapol.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/meghit.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_PLASMA</damage_type>
       </sp>
     </value>
@@ -2739,6 +2763,7 @@
         <range>100</range>
         <ttl>240</ttl>
         <explosion_graphic>26</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/megastun.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_STUN</damage_type>
       </sp>
     </value>
@@ -2873,6 +2898,7 @@
         <range>1000</range>
         <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/disruptr.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
     </value>
@@ -2951,6 +2977,7 @@
         <turn_rate>30</turn_rate>
         <range>1400</range>
         <ttl>4200</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/extra/tronlaun.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>13</explosion_depletion_rate>
       </sp>
@@ -3093,6 +3120,7 @@
         <turn_rate>35</turn_rate>
         <range>600</range>
         <ttl>1800</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec2.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ANTI-ALIEN_GAS</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3173,6 +3201,7 @@
         <turn_rate>35</turn_rate>
         <range>600</range>
         <ttl>1800</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec2.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3253,6 +3282,7 @@
         <turn_rate>35</turn_rate>
         <range>600</range>
         <ttl>1800</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec2.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3392,6 +3422,7 @@
         <range>260</range>
         <ttl>600</ttl>
         <explosion_graphic>28</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/aliens/attacks/wormspit.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
     </value>
@@ -3605,6 +3636,7 @@
         <range>40</range>
         <ttl>100</ttl>
         <explosion_graphic>23</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/powers.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_PLASMA</damage_type>
       </sp>
     </value>
@@ -3798,6 +3830,7 @@
         <range>900</range>
         <ttl>2200</ttl>
         <explosion_graphic>28</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/aliens/attacks/queenwhp.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
     </value>
@@ -3874,6 +3907,7 @@
         <range>384</range>
         <ttl>900</ttl>
         <explosion_graphic>28</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/aliens/attacks/spitter.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
     </value>
@@ -3967,6 +4001,7 @@
         <range>800</range>
         <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/toxigun.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_TOXIN_A</damage_type>
       </sp>
     </value>
@@ -4029,6 +4064,7 @@
         <range>800</range>
         <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/toxigun.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_TOXIN_B</damage_type>
       </sp>
     </value>
@@ -4091,6 +4127,7 @@
         <range>800</range>
         <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/toxigun.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_TOXIN_C</damage_type>
       </sp>
     </value>
@@ -4182,6 +4219,8 @@
         <tail_size>16</tail_size>
         <range>400</range>
         <ttl>1200</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/trakgun.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/trakhit.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_SMOKE</damage_type>
       </sp>
     </value>

--- a/data/difficulty2_patched/gamestate/battle_common_image_list.xml
+++ b/data/difficulty2_patched/gamestate/battle_common_image_list.xml
@@ -488,5 +488,11 @@
       <entry>PCKSTRAT:xcom3/tacdata/stratico.pck:xcom3/tacdata/stratico.tab:483</entry>
     </strategyImages>
     <loadingImage>xcom3/ufodata/enttact.pcx</loadingImage>
+    <focusArrows>
+      <entry>PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/icons.tab:64:xcom3/tacdata/tactical.pal</entry>
+      <entry>PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/icons.tab:65:xcom3/tacdata/tactical.pal</entry>
+      <entry>PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/icons.tab:66:xcom3/tacdata/tactical.pal</entry>
+      <entry>PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/icons.tab:67:xcom3/tacdata/tactical.pal</entry>
+    </focusArrows>
   </sp>
 </battle_common_image_list>

--- a/data/difficulty3_patched/checksum.xml
+++ b/data/difficulty3_patched/checksum.xml
@@ -2,12 +2,12 @@
 <checksums>
   <checksum SHA1="de1732555e585509f8077f0c8e03c697f3d20945">gamestate.xml</checksum>
   <checksum SHA1="e82ad81e87952471fc9a77dfdaf5c7de0b73340b">gamestate/agent_body_types.xml</checksum>
-  <checksum SHA1="79a8ad7d8df48a99dd5332d9c412ab6da8d9c2e3">gamestate/agent_equipment.xml</checksum>
+  <checksum SHA1="1cb75ee151d485e8f39310cd9139bc04a1d2ba74">gamestate/agent_equipment.xml</checksum>
   <checksum SHA1="db87a07c2ad3fe43a082e3143408dc3fd29ee9ff">gamestate/agent_equipment_layouts.xml</checksum>
   <checksum SHA1="282e2b08cda4a9a7094fb16355bd5e58cdc2a224">gamestate/agent_generator.xml</checksum>
   <checksum SHA1="665676441df08bedc9cdd1dec8854d5b99a8ed4f">gamestate/agent_types.xml</checksum>
   <checksum SHA1="0b1fc22224d3d4d266780fe20b1db95ee052bba0">gamestate/base_layouts.xml</checksum>
-  <checksum SHA1="23e3874d1ed51670e14c492e0ed06b374372fbaf">gamestate/battle_common_image_list.xml</checksum>
+  <checksum SHA1="06d9d5ee8bcce6c690cefe0cf21fc96c16896f11">gamestate/battle_common_image_list.xml</checksum>
   <checksum SHA1="5fbc9dc088736f547d742fa3ff3da34dc35e1941">gamestate/battle_common_sample_list.xml</checksum>
   <checksum SHA1="dcebd55d2b40ea7b7c117ce16ee71ab23be4e4ef">gamestate/battle_maps.xml</checksum>
   <checksum SHA1="09a0229c616b482ad6f16bdf5f90d879e648fb62">gamestate/battle_maps/BATTLEMAP_01senate.xml</checksum>

--- a/data/difficulty3_patched/checksum.xml
+++ b/data/difficulty3_patched/checksum.xml
@@ -2,7 +2,7 @@
 <checksums>
   <checksum SHA1="de1732555e585509f8077f0c8e03c697f3d20945">gamestate.xml</checksum>
   <checksum SHA1="e82ad81e87952471fc9a77dfdaf5c7de0b73340b">gamestate/agent_body_types.xml</checksum>
-  <checksum SHA1="1cb75ee151d485e8f39310cd9139bc04a1d2ba74">gamestate/agent_equipment.xml</checksum>
+  <checksum SHA1="0c98b18d8eca57f5f1e83f4c9ea28d0967e74bb5">gamestate/agent_equipment.xml</checksum>
   <checksum SHA1="db87a07c2ad3fe43a082e3143408dc3fd29ee9ff">gamestate/agent_equipment_layouts.xml</checksum>
   <checksum SHA1="282e2b08cda4a9a7094fb16355bd5e58cdc2a224">gamestate/agent_generator.xml</checksum>
   <checksum SHA1="665676441df08bedc9cdd1dec8854d5b99a8ed4f">gamestate/agent_types.xml</checksum>

--- a/data/difficulty3_patched/gamestate/agent_equipment.xml
+++ b/data/difficulty3_patched/gamestate/agent_equipment.xml
@@ -120,6 +120,7 @@
         <tail_size>26</tail_size>
         <turn_rate>40</turn_rate>
         <range>180</range>
+        <ttl>440</ttl>
         <explosion_graphic>28</explosion_graphic>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
@@ -178,6 +179,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_ANTI-ALIEN_GAS</damage_type>
         <explosion_depletion_rate>10</explosion_depletion_rate>
       </sp>
@@ -253,6 +255,7 @@
         <fire_delay>34</fire_delay>
         <tail_size>31</tail_size>
         <range>900</range>
+        <ttl>2700</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
@@ -328,6 +331,7 @@
         <fire_delay>34</fire_delay>
         <tail_size>31</tail_size>
         <range>900</range>
+        <ttl>2700</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>4</explosion_depletion_rate>
       </sp>
@@ -403,6 +407,7 @@
         <fire_delay>34</fire_delay>
         <tail_size>31</tail_size>
         <range>900</range>
+        <ttl>2700</ttl>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -463,6 +468,7 @@
         <guided>true</guided>
         <turn_rate>30</turn_rate>
         <range>400</range>
+        <ttl>1800</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <trigger_type>Boomeroid</trigger_type>
         <explosion_depletion_rate>9</explosion_depletion_rate>
@@ -575,6 +581,7 @@
         <fire_delay>64</fire_delay>
         <tail_size>34</tail_size>
         <range>500</range>
+        <ttl>1400</ttl>
         <damage_type>DAMAGETYPE_BRAINSUCKER</damage_type>
       </sp>
     </value>
@@ -653,6 +660,7 @@
         <fire_delay>40</fire_delay>
         <tail_size>35</tail_size>
         <range>1000</range>
+        <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
@@ -797,6 +805,7 @@
         <guided>true</guided>
         <turn_rate>25</turn_rate>
         <range>1400</range>
+        <ttl>4200</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>14</explosion_depletion_rate>
       </sp>
@@ -889,6 +898,7 @@
         <fire_delay>32</fire_delay>
         <tail_size>17</tail_size>
         <range>800</range>
+        <ttl>2400</ttl>
         <explosion_graphic>24</explosion_graphic>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
@@ -998,6 +1008,7 @@
         <fire_delay>40</fire_delay>
         <tail_size>35</tail_size>
         <range>1000</range>
+        <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
@@ -1112,6 +1123,7 @@
         <guided>true</guided>
         <turn_rate>18</turn_rate>
         <range>1200</range>
+        <ttl>3600</ttl>
         <explosion_graphic>28</explosion_graphic>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
@@ -1227,6 +1239,7 @@
         <guided>true</guided>
         <turn_rate>20</turn_rate>
         <range>1200</range>
+        <ttl>3600</ttl>
         <damage_type>DAMAGETYPE_ANTI-ALIEN_GAS</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1310,6 +1323,7 @@
         <guided>true</guided>
         <turn_rate>20</turn_rate>
         <range>1200</range>
+        <ttl>3600</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1393,6 +1407,7 @@
         <guided>true</guided>
         <turn_rate>20</turn_rate>
         <range>1200</range>
+        <ttl>3600</ttl>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1460,6 +1475,7 @@
         <tail_size>26</tail_size>
         <turn_rate>40</turn_rate>
         <range>50</range>
+        <ttl>120</ttl>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
     </value>
@@ -1517,6 +1533,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>12</explosion_depletion_rate>
       </sp>
@@ -1679,6 +1696,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>15</explosion_depletion_rate>
       </sp>
@@ -1820,6 +1838,7 @@
         <fire_delay>12</fire_delay>
         <tail_size>25</tail_size>
         <range>900</range>
+        <ttl>2700</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
@@ -1942,6 +1961,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <trigger_type>Proximity</trigger_type>
         <explosion_depletion_rate>9</explosion_depletion_rate>
@@ -2068,6 +2088,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>7</explosion_depletion_rate>
       </sp>
@@ -2251,6 +2272,7 @@
         <fire_delay>42</fire_delay>
         <tail_size>36</tail_size>
         <range>1200</range>
+        <ttl>3600</ttl>
         <explosion_graphic>22</explosion_graphic>
         <damage_type>DAMAGETYPE_LASER_BEAM</damage_type>
       </sp>
@@ -2374,6 +2396,7 @@
         <fire_delay>18</fire_delay>
         <tail_size>16</tail_size>
         <range>700</range>
+        <ttl>2200</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
@@ -2558,6 +2581,7 @@
         <fire_delay>30</fire_delay>
         <tail_size>36</tail_size>
         <range>900</range>
+        <ttl>2700</ttl>
         <explosion_graphic>23</explosion_graphic>
         <damage_type>DAMAGETYPE_PLASMA</damage_type>
       </sp>
@@ -2652,6 +2676,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_SMOKE</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -2712,6 +2737,7 @@
         <fire_delay>44</fire_delay>
         <tail_size>16</tail_size>
         <range>100</range>
+        <ttl>240</ttl>
         <explosion_graphic>26</explosion_graphic>
         <damage_type>DAMAGETYPE_STUN</damage_type>
       </sp>
@@ -2770,6 +2796,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_STUN_GAS</damage_type>
         <explosion_depletion_rate>12</explosion_depletion_rate>
       </sp>
@@ -2844,6 +2871,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>35</tail_size>
         <range>1000</range>
+        <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
@@ -2922,6 +2950,7 @@
         <guided>true</guided>
         <turn_rate>30</turn_rate>
         <range>1400</range>
+        <ttl>4200</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>13</explosion_depletion_rate>
       </sp>
@@ -3063,6 +3092,7 @@
         <guided>true</guided>
         <turn_rate>35</turn_rate>
         <range>600</range>
+        <ttl>1800</ttl>
         <damage_type>DAMAGETYPE_ANTI-ALIEN_GAS</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3142,6 +3172,7 @@
         <guided>true</guided>
         <turn_rate>35</turn_rate>
         <range>600</range>
+        <ttl>1800</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3221,6 +3252,7 @@
         <guided>true</guided>
         <turn_rate>35</turn_rate>
         <range>600</range>
+        <ttl>1800</ttl>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3358,6 +3390,7 @@
         <tail_size>34</tail_size>
         <turn_rate>40</turn_rate>
         <range>260</range>
+        <ttl>600</ttl>
         <explosion_graphic>28</explosion_graphic>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
@@ -3510,6 +3543,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1200</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>22</explosion_depletion_rate>
       </sp>
@@ -3569,6 +3603,7 @@
         <fire_delay>35</fire_delay>
         <tail_size>16</tail_size>
         <range>40</range>
+        <ttl>100</ttl>
         <explosion_graphic>23</explosion_graphic>
         <damage_type>DAMAGETYPE_PLASMA</damage_type>
       </sp>
@@ -3627,6 +3662,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_PSIONIC_BLAST</damage_type>
         <explosion_depletion_rate>10</explosion_depletion_rate>
       </sp>
@@ -3760,6 +3796,7 @@
         <tail_size>34</tail_size>
         <turn_rate>40</turn_rate>
         <range>900</range>
+        <ttl>2200</ttl>
         <explosion_graphic>28</explosion_graphic>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
@@ -3835,6 +3872,7 @@
         <tail_size>34</tail_size>
         <turn_rate>40</turn_rate>
         <range>384</range>
+        <ttl>900</ttl>
         <explosion_graphic>28</explosion_graphic>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
@@ -3927,6 +3965,7 @@
         <fire_delay>8</fire_delay>
         <tail_size>16</tail_size>
         <range>800</range>
+        <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_TOXIN_A</damage_type>
       </sp>
@@ -3988,6 +4027,7 @@
         <fire_delay>8</fire_delay>
         <tail_size>16</tail_size>
         <range>800</range>
+        <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_TOXIN_B</damage_type>
       </sp>
@@ -4049,6 +4089,7 @@
         <fire_delay>8</fire_delay>
         <tail_size>16</tail_size>
         <range>800</range>
+        <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_TOXIN_C</damage_type>
       </sp>
@@ -4140,6 +4181,7 @@
         <fire_delay>36</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1200</ttl>
         <damage_type>DAMAGETYPE_SMOKE</damage_type>
       </sp>
     </value>
@@ -4197,6 +4239,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>300</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>19</explosion_depletion_rate>
       </sp>

--- a/data/difficulty3_patched/gamestate/agent_equipment.xml
+++ b/data/difficulty3_patched/gamestate/agent_equipment.xml
@@ -257,6 +257,8 @@
         <range>900</range>
         <ttl>2700</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/megcanon.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet3.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
     </value>
@@ -332,6 +334,8 @@
         <tail_size>31</tail_size>
         <range>900</range>
         <ttl>2700</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/megcanon.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet3.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>4</explosion_depletion_rate>
       </sp>
@@ -408,6 +412,8 @@
         <tail_size>31</tail_size>
         <range>900</range>
         <ttl>2700</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/megcanon.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet3.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -582,6 +588,7 @@
         <tail_size>34</tail_size>
         <range>500</range>
         <ttl>1400</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/powers.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_BRAINSUCKER</damage_type>
       </sp>
     </value>
@@ -662,6 +669,7 @@
         <range>1000</range>
         <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/dcannon1.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
     </value>
@@ -806,6 +814,7 @@
         <turn_rate>25</turn_rate>
         <range>1400</range>
         <ttl>4200</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/dimnmisl.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>14</explosion_depletion_rate>
       </sp>
@@ -900,6 +909,7 @@
         <range>800</range>
         <ttl>2400</ttl>
         <explosion_graphic>24</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/disruptr.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
     </value>
@@ -1010,6 +1020,7 @@
         <range>1000</range>
         <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/dcannon1.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
     </value>
@@ -1125,6 +1136,7 @@
         <range>1200</range>
         <ttl>3600</ttl>
         <explosion_graphic>28</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/entropy.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
     </value>
@@ -1240,6 +1252,7 @@
         <turn_rate>20</turn_rate>
         <range>1200</range>
         <ttl>3600</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec1.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ANTI-ALIEN_GAS</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1324,6 +1337,7 @@
         <turn_rate>20</turn_rate>
         <range>1200</range>
         <ttl>3600</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec1.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1408,6 +1422,7 @@
         <turn_rate>20</turn_rate>
         <range>1200</range>
         <ttl>3600</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec1.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1476,6 +1491,7 @@
         <turn_rate>40</turn_rate>
         <range>50</range>
         <ttl>120</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/aliens/attacks/wrmattak.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
     </value>
@@ -1840,6 +1856,8 @@
         <range>900</range>
         <ttl>2700</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet1.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet2.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
     </value>
@@ -2274,6 +2292,8 @@
         <range>1200</range>
         <ttl>3600</ttl>
         <explosion_graphic>22</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/sniper.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/zaphit.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_LASER_BEAM</damage_type>
       </sp>
     </value>
@@ -2398,6 +2418,8 @@
         <range>700</range>
         <ttl>2200</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet1.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet2.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
     </value>
@@ -2583,6 +2605,8 @@
         <range>900</range>
         <ttl>2700</ttl>
         <explosion_graphic>23</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/megapol.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/meghit.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_PLASMA</damage_type>
       </sp>
     </value>
@@ -2739,6 +2763,7 @@
         <range>100</range>
         <ttl>240</ttl>
         <explosion_graphic>26</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/megastun.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_STUN</damage_type>
       </sp>
     </value>
@@ -2873,6 +2898,7 @@
         <range>1000</range>
         <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/disruptr.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
     </value>
@@ -2951,6 +2977,7 @@
         <turn_rate>30</turn_rate>
         <range>1400</range>
         <ttl>4200</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/extra/tronlaun.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>13</explosion_depletion_rate>
       </sp>
@@ -3093,6 +3120,7 @@
         <turn_rate>35</turn_rate>
         <range>600</range>
         <ttl>1800</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec2.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ANTI-ALIEN_GAS</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3173,6 +3201,7 @@
         <turn_rate>35</turn_rate>
         <range>600</range>
         <ttl>1800</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec2.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3253,6 +3282,7 @@
         <turn_rate>35</turn_rate>
         <range>600</range>
         <ttl>1800</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec2.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3392,6 +3422,7 @@
         <range>260</range>
         <ttl>600</ttl>
         <explosion_graphic>28</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/aliens/attacks/wormspit.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
     </value>
@@ -3605,6 +3636,7 @@
         <range>40</range>
         <ttl>100</ttl>
         <explosion_graphic>23</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/powers.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_PLASMA</damage_type>
       </sp>
     </value>
@@ -3798,6 +3830,7 @@
         <range>900</range>
         <ttl>2200</ttl>
         <explosion_graphic>28</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/aliens/attacks/queenwhp.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
     </value>
@@ -3874,6 +3907,7 @@
         <range>384</range>
         <ttl>900</ttl>
         <explosion_graphic>28</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/aliens/attacks/spitter.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
     </value>
@@ -3967,6 +4001,7 @@
         <range>800</range>
         <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/toxigun.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_TOXIN_A</damage_type>
       </sp>
     </value>
@@ -4029,6 +4064,7 @@
         <range>800</range>
         <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/toxigun.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_TOXIN_B</damage_type>
       </sp>
     </value>
@@ -4091,6 +4127,7 @@
         <range>800</range>
         <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/toxigun.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_TOXIN_C</damage_type>
       </sp>
     </value>
@@ -4182,6 +4219,8 @@
         <tail_size>16</tail_size>
         <range>400</range>
         <ttl>1200</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/trakgun.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/trakhit.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_SMOKE</damage_type>
       </sp>
     </value>

--- a/data/difficulty3_patched/gamestate/battle_common_image_list.xml
+++ b/data/difficulty3_patched/gamestate/battle_common_image_list.xml
@@ -488,5 +488,11 @@
       <entry>PCKSTRAT:xcom3/tacdata/stratico.pck:xcom3/tacdata/stratico.tab:483</entry>
     </strategyImages>
     <loadingImage>xcom3/ufodata/enttact.pcx</loadingImage>
+    <focusArrows>
+      <entry>PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/icons.tab:64:xcom3/tacdata/tactical.pal</entry>
+      <entry>PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/icons.tab:65:xcom3/tacdata/tactical.pal</entry>
+      <entry>PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/icons.tab:66:xcom3/tacdata/tactical.pal</entry>
+      <entry>PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/icons.tab:67:xcom3/tacdata/tactical.pal</entry>
+    </focusArrows>
   </sp>
 </battle_common_image_list>

--- a/data/difficulty4_patched/checksum.xml
+++ b/data/difficulty4_patched/checksum.xml
@@ -2,12 +2,12 @@
 <checksums>
   <checksum SHA1="de1732555e585509f8077f0c8e03c697f3d20945">gamestate.xml</checksum>
   <checksum SHA1="e82ad81e87952471fc9a77dfdaf5c7de0b73340b">gamestate/agent_body_types.xml</checksum>
-  <checksum SHA1="79a8ad7d8df48a99dd5332d9c412ab6da8d9c2e3">gamestate/agent_equipment.xml</checksum>
+  <checksum SHA1="1cb75ee151d485e8f39310cd9139bc04a1d2ba74">gamestate/agent_equipment.xml</checksum>
   <checksum SHA1="db87a07c2ad3fe43a082e3143408dc3fd29ee9ff">gamestate/agent_equipment_layouts.xml</checksum>
   <checksum SHA1="282e2b08cda4a9a7094fb16355bd5e58cdc2a224">gamestate/agent_generator.xml</checksum>
   <checksum SHA1="665676441df08bedc9cdd1dec8854d5b99a8ed4f">gamestate/agent_types.xml</checksum>
   <checksum SHA1="0b1fc22224d3d4d266780fe20b1db95ee052bba0">gamestate/base_layouts.xml</checksum>
-  <checksum SHA1="23e3874d1ed51670e14c492e0ed06b374372fbaf">gamestate/battle_common_image_list.xml</checksum>
+  <checksum SHA1="06d9d5ee8bcce6c690cefe0cf21fc96c16896f11">gamestate/battle_common_image_list.xml</checksum>
   <checksum SHA1="5fbc9dc088736f547d742fa3ff3da34dc35e1941">gamestate/battle_common_sample_list.xml</checksum>
   <checksum SHA1="dcebd55d2b40ea7b7c117ce16ee71ab23be4e4ef">gamestate/battle_maps.xml</checksum>
   <checksum SHA1="09a0229c616b482ad6f16bdf5f90d879e648fb62">gamestate/battle_maps/BATTLEMAP_01senate.xml</checksum>

--- a/data/difficulty4_patched/checksum.xml
+++ b/data/difficulty4_patched/checksum.xml
@@ -2,7 +2,7 @@
 <checksums>
   <checksum SHA1="de1732555e585509f8077f0c8e03c697f3d20945">gamestate.xml</checksum>
   <checksum SHA1="e82ad81e87952471fc9a77dfdaf5c7de0b73340b">gamestate/agent_body_types.xml</checksum>
-  <checksum SHA1="1cb75ee151d485e8f39310cd9139bc04a1d2ba74">gamestate/agent_equipment.xml</checksum>
+  <checksum SHA1="0c98b18d8eca57f5f1e83f4c9ea28d0967e74bb5">gamestate/agent_equipment.xml</checksum>
   <checksum SHA1="db87a07c2ad3fe43a082e3143408dc3fd29ee9ff">gamestate/agent_equipment_layouts.xml</checksum>
   <checksum SHA1="282e2b08cda4a9a7094fb16355bd5e58cdc2a224">gamestate/agent_generator.xml</checksum>
   <checksum SHA1="665676441df08bedc9cdd1dec8854d5b99a8ed4f">gamestate/agent_types.xml</checksum>

--- a/data/difficulty4_patched/gamestate/agent_equipment.xml
+++ b/data/difficulty4_patched/gamestate/agent_equipment.xml
@@ -120,6 +120,7 @@
         <tail_size>26</tail_size>
         <turn_rate>40</turn_rate>
         <range>180</range>
+        <ttl>440</ttl>
         <explosion_graphic>28</explosion_graphic>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
@@ -178,6 +179,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_ANTI-ALIEN_GAS</damage_type>
         <explosion_depletion_rate>10</explosion_depletion_rate>
       </sp>
@@ -253,6 +255,7 @@
         <fire_delay>34</fire_delay>
         <tail_size>31</tail_size>
         <range>900</range>
+        <ttl>2700</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
@@ -328,6 +331,7 @@
         <fire_delay>34</fire_delay>
         <tail_size>31</tail_size>
         <range>900</range>
+        <ttl>2700</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>4</explosion_depletion_rate>
       </sp>
@@ -403,6 +407,7 @@
         <fire_delay>34</fire_delay>
         <tail_size>31</tail_size>
         <range>900</range>
+        <ttl>2700</ttl>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -463,6 +468,7 @@
         <guided>true</guided>
         <turn_rate>30</turn_rate>
         <range>400</range>
+        <ttl>1800</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <trigger_type>Boomeroid</trigger_type>
         <explosion_depletion_rate>9</explosion_depletion_rate>
@@ -575,6 +581,7 @@
         <fire_delay>64</fire_delay>
         <tail_size>34</tail_size>
         <range>500</range>
+        <ttl>1400</ttl>
         <damage_type>DAMAGETYPE_BRAINSUCKER</damage_type>
       </sp>
     </value>
@@ -653,6 +660,7 @@
         <fire_delay>40</fire_delay>
         <tail_size>35</tail_size>
         <range>1000</range>
+        <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
@@ -797,6 +805,7 @@
         <guided>true</guided>
         <turn_rate>25</turn_rate>
         <range>1400</range>
+        <ttl>4200</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>14</explosion_depletion_rate>
       </sp>
@@ -889,6 +898,7 @@
         <fire_delay>32</fire_delay>
         <tail_size>17</tail_size>
         <range>800</range>
+        <ttl>2400</ttl>
         <explosion_graphic>24</explosion_graphic>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
@@ -998,6 +1008,7 @@
         <fire_delay>40</fire_delay>
         <tail_size>35</tail_size>
         <range>1000</range>
+        <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
@@ -1112,6 +1123,7 @@
         <guided>true</guided>
         <turn_rate>18</turn_rate>
         <range>1200</range>
+        <ttl>3600</ttl>
         <explosion_graphic>28</explosion_graphic>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
@@ -1227,6 +1239,7 @@
         <guided>true</guided>
         <turn_rate>20</turn_rate>
         <range>1200</range>
+        <ttl>3600</ttl>
         <damage_type>DAMAGETYPE_ANTI-ALIEN_GAS</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1310,6 +1323,7 @@
         <guided>true</guided>
         <turn_rate>20</turn_rate>
         <range>1200</range>
+        <ttl>3600</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1393,6 +1407,7 @@
         <guided>true</guided>
         <turn_rate>20</turn_rate>
         <range>1200</range>
+        <ttl>3600</ttl>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1460,6 +1475,7 @@
         <tail_size>26</tail_size>
         <turn_rate>40</turn_rate>
         <range>50</range>
+        <ttl>120</ttl>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
     </value>
@@ -1517,6 +1533,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>12</explosion_depletion_rate>
       </sp>
@@ -1679,6 +1696,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>15</explosion_depletion_rate>
       </sp>
@@ -1820,6 +1838,7 @@
         <fire_delay>12</fire_delay>
         <tail_size>25</tail_size>
         <range>900</range>
+        <ttl>2700</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
@@ -1942,6 +1961,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <trigger_type>Proximity</trigger_type>
         <explosion_depletion_rate>9</explosion_depletion_rate>
@@ -2068,6 +2088,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>7</explosion_depletion_rate>
       </sp>
@@ -2251,6 +2272,7 @@
         <fire_delay>42</fire_delay>
         <tail_size>36</tail_size>
         <range>1200</range>
+        <ttl>3600</ttl>
         <explosion_graphic>22</explosion_graphic>
         <damage_type>DAMAGETYPE_LASER_BEAM</damage_type>
       </sp>
@@ -2374,6 +2396,7 @@
         <fire_delay>18</fire_delay>
         <tail_size>16</tail_size>
         <range>700</range>
+        <ttl>2200</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
@@ -2558,6 +2581,7 @@
         <fire_delay>30</fire_delay>
         <tail_size>36</tail_size>
         <range>900</range>
+        <ttl>2700</ttl>
         <explosion_graphic>23</explosion_graphic>
         <damage_type>DAMAGETYPE_PLASMA</damage_type>
       </sp>
@@ -2652,6 +2676,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_SMOKE</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -2712,6 +2737,7 @@
         <fire_delay>44</fire_delay>
         <tail_size>16</tail_size>
         <range>100</range>
+        <ttl>240</ttl>
         <explosion_graphic>26</explosion_graphic>
         <damage_type>DAMAGETYPE_STUN</damage_type>
       </sp>
@@ -2770,6 +2796,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_STUN_GAS</damage_type>
         <explosion_depletion_rate>12</explosion_depletion_rate>
       </sp>
@@ -2844,6 +2871,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>35</tail_size>
         <range>1000</range>
+        <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
@@ -2922,6 +2950,7 @@
         <guided>true</guided>
         <turn_rate>30</turn_rate>
         <range>1400</range>
+        <ttl>4200</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>13</explosion_depletion_rate>
       </sp>
@@ -3063,6 +3092,7 @@
         <guided>true</guided>
         <turn_rate>35</turn_rate>
         <range>600</range>
+        <ttl>1800</ttl>
         <damage_type>DAMAGETYPE_ANTI-ALIEN_GAS</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3142,6 +3172,7 @@
         <guided>true</guided>
         <turn_rate>35</turn_rate>
         <range>600</range>
+        <ttl>1800</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3221,6 +3252,7 @@
         <guided>true</guided>
         <turn_rate>35</turn_rate>
         <range>600</range>
+        <ttl>1800</ttl>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3358,6 +3390,7 @@
         <tail_size>34</tail_size>
         <turn_rate>40</turn_rate>
         <range>260</range>
+        <ttl>600</ttl>
         <explosion_graphic>28</explosion_graphic>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
@@ -3510,6 +3543,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1200</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>22</explosion_depletion_rate>
       </sp>
@@ -3569,6 +3603,7 @@
         <fire_delay>35</fire_delay>
         <tail_size>16</tail_size>
         <range>40</range>
+        <ttl>100</ttl>
         <explosion_graphic>23</explosion_graphic>
         <damage_type>DAMAGETYPE_PLASMA</damage_type>
       </sp>
@@ -3627,6 +3662,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_PSIONIC_BLAST</damage_type>
         <explosion_depletion_rate>10</explosion_depletion_rate>
       </sp>
@@ -3760,6 +3796,7 @@
         <tail_size>34</tail_size>
         <turn_rate>40</turn_rate>
         <range>900</range>
+        <ttl>2200</ttl>
         <explosion_graphic>28</explosion_graphic>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
@@ -3835,6 +3872,7 @@
         <tail_size>34</tail_size>
         <turn_rate>40</turn_rate>
         <range>384</range>
+        <ttl>900</ttl>
         <explosion_graphic>28</explosion_graphic>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
@@ -3927,6 +3965,7 @@
         <fire_delay>8</fire_delay>
         <tail_size>16</tail_size>
         <range>800</range>
+        <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_TOXIN_A</damage_type>
       </sp>
@@ -3988,6 +4027,7 @@
         <fire_delay>8</fire_delay>
         <tail_size>16</tail_size>
         <range>800</range>
+        <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_TOXIN_B</damage_type>
       </sp>
@@ -4049,6 +4089,7 @@
         <fire_delay>8</fire_delay>
         <tail_size>16</tail_size>
         <range>800</range>
+        <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_TOXIN_C</damage_type>
       </sp>
@@ -4140,6 +4181,7 @@
         <fire_delay>36</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1200</ttl>
         <damage_type>DAMAGETYPE_SMOKE</damage_type>
       </sp>
     </value>
@@ -4197,6 +4239,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>300</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>19</explosion_depletion_rate>
       </sp>

--- a/data/difficulty4_patched/gamestate/agent_equipment.xml
+++ b/data/difficulty4_patched/gamestate/agent_equipment.xml
@@ -257,6 +257,8 @@
         <range>900</range>
         <ttl>2700</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/megcanon.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet3.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
     </value>
@@ -332,6 +334,8 @@
         <tail_size>31</tail_size>
         <range>900</range>
         <ttl>2700</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/megcanon.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet3.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>4</explosion_depletion_rate>
       </sp>
@@ -408,6 +412,8 @@
         <tail_size>31</tail_size>
         <range>900</range>
         <ttl>2700</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/megcanon.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet3.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -582,6 +588,7 @@
         <tail_size>34</tail_size>
         <range>500</range>
         <ttl>1400</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/powers.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_BRAINSUCKER</damage_type>
       </sp>
     </value>
@@ -662,6 +669,7 @@
         <range>1000</range>
         <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/dcannon1.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
     </value>
@@ -806,6 +814,7 @@
         <turn_rate>25</turn_rate>
         <range>1400</range>
         <ttl>4200</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/dimnmisl.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>14</explosion_depletion_rate>
       </sp>
@@ -900,6 +909,7 @@
         <range>800</range>
         <ttl>2400</ttl>
         <explosion_graphic>24</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/disruptr.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
     </value>
@@ -1010,6 +1020,7 @@
         <range>1000</range>
         <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/dcannon1.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
     </value>
@@ -1125,6 +1136,7 @@
         <range>1200</range>
         <ttl>3600</ttl>
         <explosion_graphic>28</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/entropy.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
     </value>
@@ -1240,6 +1252,7 @@
         <turn_rate>20</turn_rate>
         <range>1200</range>
         <ttl>3600</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec1.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ANTI-ALIEN_GAS</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1324,6 +1337,7 @@
         <turn_rate>20</turn_rate>
         <range>1200</range>
         <ttl>3600</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec1.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1408,6 +1422,7 @@
         <turn_rate>20</turn_rate>
         <range>1200</range>
         <ttl>3600</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec1.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1476,6 +1491,7 @@
         <turn_rate>40</turn_rate>
         <range>50</range>
         <ttl>120</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/aliens/attacks/wrmattak.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
     </value>
@@ -1840,6 +1856,8 @@
         <range>900</range>
         <ttl>2700</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet1.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet2.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
     </value>
@@ -2274,6 +2292,8 @@
         <range>1200</range>
         <ttl>3600</ttl>
         <explosion_graphic>22</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/sniper.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/zaphit.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_LASER_BEAM</damage_type>
       </sp>
     </value>
@@ -2398,6 +2418,8 @@
         <range>700</range>
         <ttl>2200</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet1.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet2.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
     </value>
@@ -2583,6 +2605,8 @@
         <range>900</range>
         <ttl>2700</ttl>
         <explosion_graphic>23</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/megapol.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/meghit.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_PLASMA</damage_type>
       </sp>
     </value>
@@ -2739,6 +2763,7 @@
         <range>100</range>
         <ttl>240</ttl>
         <explosion_graphic>26</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/megastun.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_STUN</damage_type>
       </sp>
     </value>
@@ -2873,6 +2898,7 @@
         <range>1000</range>
         <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/disruptr.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
     </value>
@@ -2951,6 +2977,7 @@
         <turn_rate>30</turn_rate>
         <range>1400</range>
         <ttl>4200</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/extra/tronlaun.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>13</explosion_depletion_rate>
       </sp>
@@ -3093,6 +3120,7 @@
         <turn_rate>35</turn_rate>
         <range>600</range>
         <ttl>1800</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec2.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ANTI-ALIEN_GAS</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3173,6 +3201,7 @@
         <turn_rate>35</turn_rate>
         <range>600</range>
         <ttl>1800</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec2.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3253,6 +3282,7 @@
         <turn_rate>35</turn_rate>
         <range>600</range>
         <ttl>1800</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec2.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3392,6 +3422,7 @@
         <range>260</range>
         <ttl>600</ttl>
         <explosion_graphic>28</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/aliens/attacks/wormspit.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
     </value>
@@ -3605,6 +3636,7 @@
         <range>40</range>
         <ttl>100</ttl>
         <explosion_graphic>23</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/powers.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_PLASMA</damage_type>
       </sp>
     </value>
@@ -3798,6 +3830,7 @@
         <range>900</range>
         <ttl>2200</ttl>
         <explosion_graphic>28</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/aliens/attacks/queenwhp.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
     </value>
@@ -3874,6 +3907,7 @@
         <range>384</range>
         <ttl>900</ttl>
         <explosion_graphic>28</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/aliens/attacks/spitter.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
     </value>
@@ -3967,6 +4001,7 @@
         <range>800</range>
         <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/toxigun.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_TOXIN_A</damage_type>
       </sp>
     </value>
@@ -4029,6 +4064,7 @@
         <range>800</range>
         <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/toxigun.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_TOXIN_B</damage_type>
       </sp>
     </value>
@@ -4091,6 +4127,7 @@
         <range>800</range>
         <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/toxigun.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_TOXIN_C</damage_type>
       </sp>
     </value>
@@ -4182,6 +4219,8 @@
         <tail_size>16</tail_size>
         <range>400</range>
         <ttl>1200</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/trakgun.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/trakhit.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_SMOKE</damage_type>
       </sp>
     </value>

--- a/data/difficulty4_patched/gamestate/battle_common_image_list.xml
+++ b/data/difficulty4_patched/gamestate/battle_common_image_list.xml
@@ -488,5 +488,11 @@
       <entry>PCKSTRAT:xcom3/tacdata/stratico.pck:xcom3/tacdata/stratico.tab:483</entry>
     </strategyImages>
     <loadingImage>xcom3/ufodata/enttact.pcx</loadingImage>
+    <focusArrows>
+      <entry>PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/icons.tab:64:xcom3/tacdata/tactical.pal</entry>
+      <entry>PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/icons.tab:65:xcom3/tacdata/tactical.pal</entry>
+      <entry>PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/icons.tab:66:xcom3/tacdata/tactical.pal</entry>
+      <entry>PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/icons.tab:67:xcom3/tacdata/tactical.pal</entry>
+    </focusArrows>
   </sp>
 </battle_common_image_list>

--- a/data/difficulty5_patched/checksum.xml
+++ b/data/difficulty5_patched/checksum.xml
@@ -2,12 +2,12 @@
 <checksums>
   <checksum SHA1="de1732555e585509f8077f0c8e03c697f3d20945">gamestate.xml</checksum>
   <checksum SHA1="e82ad81e87952471fc9a77dfdaf5c7de0b73340b">gamestate/agent_body_types.xml</checksum>
-  <checksum SHA1="79a8ad7d8df48a99dd5332d9c412ab6da8d9c2e3">gamestate/agent_equipment.xml</checksum>
+  <checksum SHA1="1cb75ee151d485e8f39310cd9139bc04a1d2ba74">gamestate/agent_equipment.xml</checksum>
   <checksum SHA1="db87a07c2ad3fe43a082e3143408dc3fd29ee9ff">gamestate/agent_equipment_layouts.xml</checksum>
   <checksum SHA1="282e2b08cda4a9a7094fb16355bd5e58cdc2a224">gamestate/agent_generator.xml</checksum>
   <checksum SHA1="665676441df08bedc9cdd1dec8854d5b99a8ed4f">gamestate/agent_types.xml</checksum>
   <checksum SHA1="0b1fc22224d3d4d266780fe20b1db95ee052bba0">gamestate/base_layouts.xml</checksum>
-  <checksum SHA1="23e3874d1ed51670e14c492e0ed06b374372fbaf">gamestate/battle_common_image_list.xml</checksum>
+  <checksum SHA1="06d9d5ee8bcce6c690cefe0cf21fc96c16896f11">gamestate/battle_common_image_list.xml</checksum>
   <checksum SHA1="5fbc9dc088736f547d742fa3ff3da34dc35e1941">gamestate/battle_common_sample_list.xml</checksum>
   <checksum SHA1="dcebd55d2b40ea7b7c117ce16ee71ab23be4e4ef">gamestate/battle_maps.xml</checksum>
   <checksum SHA1="09a0229c616b482ad6f16bdf5f90d879e648fb62">gamestate/battle_maps/BATTLEMAP_01senate.xml</checksum>

--- a/data/difficulty5_patched/checksum.xml
+++ b/data/difficulty5_patched/checksum.xml
@@ -2,7 +2,7 @@
 <checksums>
   <checksum SHA1="de1732555e585509f8077f0c8e03c697f3d20945">gamestate.xml</checksum>
   <checksum SHA1="e82ad81e87952471fc9a77dfdaf5c7de0b73340b">gamestate/agent_body_types.xml</checksum>
-  <checksum SHA1="1cb75ee151d485e8f39310cd9139bc04a1d2ba74">gamestate/agent_equipment.xml</checksum>
+  <checksum SHA1="0c98b18d8eca57f5f1e83f4c9ea28d0967e74bb5">gamestate/agent_equipment.xml</checksum>
   <checksum SHA1="db87a07c2ad3fe43a082e3143408dc3fd29ee9ff">gamestate/agent_equipment_layouts.xml</checksum>
   <checksum SHA1="282e2b08cda4a9a7094fb16355bd5e58cdc2a224">gamestate/agent_generator.xml</checksum>
   <checksum SHA1="665676441df08bedc9cdd1dec8854d5b99a8ed4f">gamestate/agent_types.xml</checksum>

--- a/data/difficulty5_patched/gamestate/agent_equipment.xml
+++ b/data/difficulty5_patched/gamestate/agent_equipment.xml
@@ -120,6 +120,7 @@
         <tail_size>26</tail_size>
         <turn_rate>40</turn_rate>
         <range>180</range>
+        <ttl>440</ttl>
         <explosion_graphic>28</explosion_graphic>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
@@ -178,6 +179,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_ANTI-ALIEN_GAS</damage_type>
         <explosion_depletion_rate>10</explosion_depletion_rate>
       </sp>
@@ -253,6 +255,7 @@
         <fire_delay>34</fire_delay>
         <tail_size>31</tail_size>
         <range>900</range>
+        <ttl>2700</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
@@ -328,6 +331,7 @@
         <fire_delay>34</fire_delay>
         <tail_size>31</tail_size>
         <range>900</range>
+        <ttl>2700</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>4</explosion_depletion_rate>
       </sp>
@@ -403,6 +407,7 @@
         <fire_delay>34</fire_delay>
         <tail_size>31</tail_size>
         <range>900</range>
+        <ttl>2700</ttl>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -463,6 +468,7 @@
         <guided>true</guided>
         <turn_rate>30</turn_rate>
         <range>400</range>
+        <ttl>1800</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <trigger_type>Boomeroid</trigger_type>
         <explosion_depletion_rate>9</explosion_depletion_rate>
@@ -575,6 +581,7 @@
         <fire_delay>64</fire_delay>
         <tail_size>34</tail_size>
         <range>500</range>
+        <ttl>1400</ttl>
         <damage_type>DAMAGETYPE_BRAINSUCKER</damage_type>
       </sp>
     </value>
@@ -653,6 +660,7 @@
         <fire_delay>40</fire_delay>
         <tail_size>35</tail_size>
         <range>1000</range>
+        <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
@@ -797,6 +805,7 @@
         <guided>true</guided>
         <turn_rate>25</turn_rate>
         <range>1400</range>
+        <ttl>4200</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>14</explosion_depletion_rate>
       </sp>
@@ -889,6 +898,7 @@
         <fire_delay>32</fire_delay>
         <tail_size>17</tail_size>
         <range>800</range>
+        <ttl>2400</ttl>
         <explosion_graphic>24</explosion_graphic>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
@@ -998,6 +1008,7 @@
         <fire_delay>40</fire_delay>
         <tail_size>35</tail_size>
         <range>1000</range>
+        <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
@@ -1112,6 +1123,7 @@
         <guided>true</guided>
         <turn_rate>18</turn_rate>
         <range>1200</range>
+        <ttl>3600</ttl>
         <explosion_graphic>28</explosion_graphic>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
@@ -1227,6 +1239,7 @@
         <guided>true</guided>
         <turn_rate>20</turn_rate>
         <range>1200</range>
+        <ttl>3600</ttl>
         <damage_type>DAMAGETYPE_ANTI-ALIEN_GAS</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1310,6 +1323,7 @@
         <guided>true</guided>
         <turn_rate>20</turn_rate>
         <range>1200</range>
+        <ttl>3600</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1393,6 +1407,7 @@
         <guided>true</guided>
         <turn_rate>20</turn_rate>
         <range>1200</range>
+        <ttl>3600</ttl>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1460,6 +1475,7 @@
         <tail_size>26</tail_size>
         <turn_rate>40</turn_rate>
         <range>50</range>
+        <ttl>120</ttl>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
     </value>
@@ -1517,6 +1533,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>12</explosion_depletion_rate>
       </sp>
@@ -1679,6 +1696,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>15</explosion_depletion_rate>
       </sp>
@@ -1820,6 +1838,7 @@
         <fire_delay>12</fire_delay>
         <tail_size>25</tail_size>
         <range>900</range>
+        <ttl>2700</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
@@ -1942,6 +1961,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <trigger_type>Proximity</trigger_type>
         <explosion_depletion_rate>9</explosion_depletion_rate>
@@ -2068,6 +2088,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>7</explosion_depletion_rate>
       </sp>
@@ -2251,6 +2272,7 @@
         <fire_delay>42</fire_delay>
         <tail_size>36</tail_size>
         <range>1200</range>
+        <ttl>3600</ttl>
         <explosion_graphic>22</explosion_graphic>
         <damage_type>DAMAGETYPE_LASER_BEAM</damage_type>
       </sp>
@@ -2374,6 +2396,7 @@
         <fire_delay>18</fire_delay>
         <tail_size>16</tail_size>
         <range>700</range>
+        <ttl>2200</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
@@ -2558,6 +2581,7 @@
         <fire_delay>30</fire_delay>
         <tail_size>36</tail_size>
         <range>900</range>
+        <ttl>2700</ttl>
         <explosion_graphic>23</explosion_graphic>
         <damage_type>DAMAGETYPE_PLASMA</damage_type>
       </sp>
@@ -2652,6 +2676,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_SMOKE</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -2712,6 +2737,7 @@
         <fire_delay>44</fire_delay>
         <tail_size>16</tail_size>
         <range>100</range>
+        <ttl>240</ttl>
         <explosion_graphic>26</explosion_graphic>
         <damage_type>DAMAGETYPE_STUN</damage_type>
       </sp>
@@ -2770,6 +2796,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_STUN_GAS</damage_type>
         <explosion_depletion_rate>12</explosion_depletion_rate>
       </sp>
@@ -2844,6 +2871,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>35</tail_size>
         <range>1000</range>
+        <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
@@ -2922,6 +2950,7 @@
         <guided>true</guided>
         <turn_rate>30</turn_rate>
         <range>1400</range>
+        <ttl>4200</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>13</explosion_depletion_rate>
       </sp>
@@ -3063,6 +3092,7 @@
         <guided>true</guided>
         <turn_rate>35</turn_rate>
         <range>600</range>
+        <ttl>1800</ttl>
         <damage_type>DAMAGETYPE_ANTI-ALIEN_GAS</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3142,6 +3172,7 @@
         <guided>true</guided>
         <turn_rate>35</turn_rate>
         <range>600</range>
+        <ttl>1800</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3221,6 +3252,7 @@
         <guided>true</guided>
         <turn_rate>35</turn_rate>
         <range>600</range>
+        <ttl>1800</ttl>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3358,6 +3390,7 @@
         <tail_size>34</tail_size>
         <turn_rate>40</turn_rate>
         <range>260</range>
+        <ttl>600</ttl>
         <explosion_graphic>28</explosion_graphic>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
@@ -3510,6 +3543,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1200</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>22</explosion_depletion_rate>
       </sp>
@@ -3569,6 +3603,7 @@
         <fire_delay>35</fire_delay>
         <tail_size>16</tail_size>
         <range>40</range>
+        <ttl>100</ttl>
         <explosion_graphic>23</explosion_graphic>
         <damage_type>DAMAGETYPE_PLASMA</damage_type>
       </sp>
@@ -3627,6 +3662,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_PSIONIC_BLAST</damage_type>
         <explosion_depletion_rate>10</explosion_depletion_rate>
       </sp>
@@ -3760,6 +3796,7 @@
         <tail_size>34</tail_size>
         <turn_rate>40</turn_rate>
         <range>900</range>
+        <ttl>2200</ttl>
         <explosion_graphic>28</explosion_graphic>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
@@ -3835,6 +3872,7 @@
         <tail_size>34</tail_size>
         <turn_rate>40</turn_rate>
         <range>384</range>
+        <ttl>900</ttl>
         <explosion_graphic>28</explosion_graphic>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
@@ -3927,6 +3965,7 @@
         <fire_delay>8</fire_delay>
         <tail_size>16</tail_size>
         <range>800</range>
+        <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_TOXIN_A</damage_type>
       </sp>
@@ -3988,6 +4027,7 @@
         <fire_delay>8</fire_delay>
         <tail_size>16</tail_size>
         <range>800</range>
+        <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_TOXIN_B</damage_type>
       </sp>
@@ -4049,6 +4089,7 @@
         <fire_delay>8</fire_delay>
         <tail_size>16</tail_size>
         <range>800</range>
+        <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
         <damage_type>DAMAGETYPE_TOXIN_C</damage_type>
       </sp>
@@ -4140,6 +4181,7 @@
         <fire_delay>36</fire_delay>
         <tail_size>16</tail_size>
         <range>400</range>
+        <ttl>1200</ttl>
         <damage_type>DAMAGETYPE_SMOKE</damage_type>
       </sp>
     </value>
@@ -4197,6 +4239,7 @@
         <fire_delay>60</fire_delay>
         <tail_size>16</tail_size>
         <range>300</range>
+        <ttl>1000</ttl>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>19</explosion_depletion_rate>
       </sp>

--- a/data/difficulty5_patched/gamestate/agent_equipment.xml
+++ b/data/difficulty5_patched/gamestate/agent_equipment.xml
@@ -257,6 +257,8 @@
         <range>900</range>
         <ttl>2700</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/megcanon.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet3.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
     </value>
@@ -332,6 +334,8 @@
         <tail_size>31</tail_size>
         <range>900</range>
         <ttl>2700</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/megcanon.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet3.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>4</explosion_depletion_rate>
       </sp>
@@ -408,6 +412,8 @@
         <tail_size>31</tail_size>
         <range>900</range>
         <ttl>2700</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/megcanon.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet3.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -582,6 +588,7 @@
         <tail_size>34</tail_size>
         <range>500</range>
         <ttl>1400</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/powers.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_BRAINSUCKER</damage_type>
       </sp>
     </value>
@@ -662,6 +669,7 @@
         <range>1000</range>
         <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/dcannon1.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
     </value>
@@ -806,6 +814,7 @@
         <turn_rate>25</turn_rate>
         <range>1400</range>
         <ttl>4200</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/dimnmisl.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>14</explosion_depletion_rate>
       </sp>
@@ -900,6 +909,7 @@
         <range>800</range>
         <ttl>2400</ttl>
         <explosion_graphic>24</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/disruptr.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
     </value>
@@ -1010,6 +1020,7 @@
         <range>1000</range>
         <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/dcannon1.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
     </value>
@@ -1125,6 +1136,7 @@
         <range>1200</range>
         <ttl>3600</ttl>
         <explosion_graphic>28</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/entropy.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
     </value>
@@ -1240,6 +1252,7 @@
         <turn_rate>20</turn_rate>
         <range>1200</range>
         <ttl>3600</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec1.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ANTI-ALIEN_GAS</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1324,6 +1337,7 @@
         <turn_rate>20</turn_rate>
         <range>1200</range>
         <ttl>3600</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec1.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1408,6 +1422,7 @@
         <turn_rate>20</turn_rate>
         <range>1200</range>
         <ttl>3600</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec1.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>11</explosion_depletion_rate>
       </sp>
@@ -1476,6 +1491,7 @@
         <turn_rate>40</turn_rate>
         <range>50</range>
         <ttl>120</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/aliens/attacks/wrmattak.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
     </value>
@@ -1840,6 +1856,8 @@
         <range>900</range>
         <ttl>2700</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet1.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet2.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
     </value>
@@ -2274,6 +2292,8 @@
         <range>1200</range>
         <ttl>3600</ttl>
         <explosion_graphic>22</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/sniper.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/zaphit.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_LASER_BEAM</damage_type>
       </sp>
     </value>
@@ -2398,6 +2418,8 @@
         <range>700</range>
         <ttl>2200</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet1.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/bullet2.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_ARMOR_PIERCING</damage_type>
       </sp>
     </value>
@@ -2583,6 +2605,8 @@
         <range>900</range>
         <ttl>2700</ttl>
         <explosion_graphic>23</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/megapol.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/meghit.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_PLASMA</damage_type>
       </sp>
     </value>
@@ -2739,6 +2763,7 @@
         <range>100</range>
         <ttl>240</ttl>
         <explosion_graphic>26</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/megastun.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_STUN</damage_type>
       </sp>
     </value>
@@ -2873,6 +2898,7 @@
         <range>1000</range>
         <ttl>3000</ttl>
         <explosion_graphic>25</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/disruptr.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_DISRUPTOR_BEAM</damage_type>
       </sp>
     </value>
@@ -2951,6 +2977,7 @@
         <turn_rate>30</turn_rate>
         <range>1400</range>
         <ttl>4200</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/extra/tronlaun.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>13</explosion_depletion_rate>
       </sp>
@@ -3093,6 +3120,7 @@
         <turn_rate>35</turn_rate>
         <range>600</range>
         <ttl>1800</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec2.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ANTI-ALIEN_GAS</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3173,6 +3201,7 @@
         <turn_rate>35</turn_rate>
         <range>600</range>
         <ttl>1800</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec2.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_EXPLOSIVE</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3253,6 +3282,7 @@
         <turn_rate>35</turn_rate>
         <range>600</range>
         <ttl>1800</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/marsec2.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_INCENDIARY</damage_type>
         <explosion_depletion_rate>5</explosion_depletion_rate>
       </sp>
@@ -3392,6 +3422,7 @@
         <range>260</range>
         <ttl>600</ttl>
         <explosion_graphic>28</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/aliens/attacks/wormspit.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
     </value>
@@ -3605,6 +3636,7 @@
         <range>40</range>
         <ttl>100</ttl>
         <explosion_graphic>23</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/powers.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_PLASMA</damage_type>
       </sp>
     </value>
@@ -3798,6 +3830,7 @@
         <range>900</range>
         <ttl>2200</ttl>
         <explosion_graphic>28</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/aliens/attacks/queenwhp.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
     </value>
@@ -3874,6 +3907,7 @@
         <range>384</range>
         <ttl>900</ttl>
         <explosion_graphic>28</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/aliens/attacks/spitter.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_ENTROPY_ENZYME</damage_type>
       </sp>
     </value>
@@ -3967,6 +4001,7 @@
         <range>800</range>
         <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/toxigun.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_TOXIN_A</damage_type>
       </sp>
     </value>
@@ -4029,6 +4064,7 @@
         <range>800</range>
         <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/toxigun.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_TOXIN_B</damage_type>
       </sp>
     </value>
@@ -4091,6 +4127,7 @@
         <range>800</range>
         <ttl>2400</ttl>
         <explosion_graphic>21</explosion_graphic>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/toxigun.raw:22050</fire_sfx>
         <damage_type>DAMAGETYPE_TOXIN_C</damage_type>
       </sp>
     </value>
@@ -4182,6 +4219,8 @@
         <tail_size>16</tail_size>
         <range>400</range>
         <ttl>1200</ttl>
+        <fire_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/trakgun.raw:22050</fire_sfx>
+        <impact_sfx>RAWSOUND:xcom3/rawsound/tactical/weapons/trakhit.raw:22050</impact_sfx>
         <damage_type>DAMAGETYPE_SMOKE</damage_type>
       </sp>
     </value>

--- a/data/difficulty5_patched/gamestate/battle_common_image_list.xml
+++ b/data/difficulty5_patched/gamestate/battle_common_image_list.xml
@@ -488,5 +488,11 @@
       <entry>PCKSTRAT:xcom3/tacdata/stratico.pck:xcom3/tacdata/stratico.tab:483</entry>
     </strategyImages>
     <loadingImage>xcom3/ufodata/enttact.pcx</loadingImage>
+    <focusArrows>
+      <entry>PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/icons.tab:64:xcom3/tacdata/tactical.pal</entry>
+      <entry>PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/icons.tab:65:xcom3/tacdata/tactical.pal</entry>
+      <entry>PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/icons.tab:66:xcom3/tacdata/tactical.pal</entry>
+      <entry>PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/icons.tab:67:xcom3/tacdata/tactical.pal</entry>
+    </focusArrows>
   </sp>
 </battle_common_image_list>

--- a/game/state/aequipment.cpp
+++ b/game/state/aequipment.cpp
@@ -1,11 +1,11 @@
 #include "game/state/aequipment.h"
 #include "framework/framework.h"
-#include "game/state/city/projectile.h"
 #include "framework/logger.h"
 #include "game/state/agent.h"
+#include "game/state/city/projectile.h"
 #include "game/state/rules/aequipment_type.h"
-#include "library/sp.h"
 #include "game/state/tileview/tileobject_battleunit.h"
+#include "library/sp.h"
 
 namespace OpenApoc
 {
@@ -34,7 +34,7 @@ int AEquipment::getAccuracy(AgentType::BodyState bodyState, BattleUnit::FireAimi
 	       (bodyState == AgentType::BodyState::Flying
 	            ? 90
 	            : (bodyState == AgentType::BodyState::Kneeling ? 110 : 100)) /
-	       100 / 100  * (int)fireMode / 4;
+	       100 / 100 * (int)fireMode / 4;
 }
 
 void AEquipment::stopFiring()
@@ -43,7 +43,7 @@ void AEquipment::stopFiring()
 	readyToFire = false;
 }
 
-void  AEquipment::startFiring(BattleUnit::FireAimingMode fireMode)
+void AEquipment::startFiring(BattleUnit::FireAimingMode fireMode)
 {
 	if (ammo == 0)
 		return;
@@ -56,7 +56,8 @@ void AEquipment::update(unsigned int ticks)
 {
 	// Recharge update
 	auto payload = getPayloadType();
-	if (payload->recharge > 0 && ammo < payload->max_ammo);
+	if (payload->recharge > 0 && ammo < payload->max_ammo)
+		;
 	{
 		recharge_ticks_accumulated += ticks;
 	}
@@ -80,41 +81,41 @@ void AEquipment::update(unsigned int ticks)
 			readyToFire = true;
 		}
 	}
-	
+
 	// If firing - confirm we're still in business
 	if (isFiring())
 	{
 		switch (equippedSlotType)
 		{
-		// Check if we're still firing
-		case AgentEquipmentLayout::EquipmentSlotType::LeftHand:
-			if (ownerAgent->unit->weaponStatus != BattleUnit::WeaponStatus::FiringBothHands
-				&&ownerAgent->unit->weaponStatus != BattleUnit::WeaponStatus::FiringLeftHand)
-			{
+			// Check if we're still firing
+			case AgentEquipmentLayout::EquipmentSlotType::LeftHand:
+				if (ownerAgent->unit->weaponStatus != BattleUnit::WeaponStatus::FiringBothHands &&
+				    ownerAgent->unit->weaponStatus != BattleUnit::WeaponStatus::FiringLeftHand)
+				{
+					stopFiring();
+				}
+				else if (ownerAgent->unit->fire_aiming_mode != aimingMode)
+				{
+					startFiring(ownerAgent->unit->fire_aiming_mode);
+				}
+				break;
+			case AgentEquipmentLayout::EquipmentSlotType::RightHand:
+				if (ownerAgent->unit->weaponStatus != BattleUnit::WeaponStatus::FiringBothHands &&
+				    ownerAgent->unit->weaponStatus != BattleUnit::WeaponStatus::FiringRightHand)
+				{
+					stopFiring();
+				}
+				else if (ownerAgent->unit->fire_aiming_mode != aimingMode)
+				{
+					startFiring(ownerAgent->unit->fire_aiming_mode);
+				}
+				break;
+			// If weapon was dropped, we should stop firing
+			case AgentEquipmentLayout::EquipmentSlotType::None:
+			// If weapon was moved to any other slot from hands, stop firing
+			default:
 				stopFiring();
-			}
-			else if (ownerAgent->unit->fire_aiming_mode != aimingMode)
-			{
-				startFiring(ownerAgent->unit->fire_aiming_mode);
-			}
-			break;
-		case AgentEquipmentLayout::EquipmentSlotType::RightHand:
-			if (ownerAgent->unit->weaponStatus != BattleUnit::WeaponStatus::FiringBothHands
-				&&ownerAgent->unit->weaponStatus != BattleUnit::WeaponStatus::FiringRightHand)
-			{
-				stopFiring();
-			}
-			else if (ownerAgent->unit->fire_aiming_mode != aimingMode)
-			{
-				startFiring(ownerAgent->unit->fire_aiming_mode);
-			}
-			break;
-		// If weapon was dropped, we should stop firing
-		case AgentEquipmentLayout::EquipmentSlotType::None:
-		// If weapon was moved to any other slot from hands, stop firing
-		default:
-			stopFiring();
-			break;
+				break;
 		}
 	}
 
@@ -133,7 +134,7 @@ sp<Projectile> AEquipment::fire(Vec3<float> target)
 		LogError("fire() called on non-ready Weapon");
 		return nullptr;
 	}
-	
+
 	readyToFire = false;
 	auto unit = ownerAgent->unit;
 	auto payload = getPayloadType();
@@ -146,20 +147,20 @@ sp<Projectile> AEquipment::fire(Vec3<float> target)
 	}
 
 	// FIXME: Apply accuracy
-	auto unitPos = unit->position + Vec3<float>{0.0f, 0.0f, (float)unit->getCurrentHeight() / 40.0f};
+	auto unitPos =
+	    unit->position + Vec3<float>{0.0f, 0.0f, (float)unit->getCurrentHeight() / 40.0f};
 	Vec3<float> velocity = target - unitPos;
 	velocity = glm::normalize(velocity);
-	velocity *= payload->speed * TICK_SCALE / 4;// I believe this is the correct formula
+	velocity *= payload->speed * TICK_SCALE / 4; // I believe this is the correct formula
 
-	return mksp<Projectile>(unit, unitPos, velocity,
-		payload->ttl * 4, payload->damage, payload->tail_size, payload->projectile_sprites, payload->impact_sfx);
+	return mksp<Projectile>(unit, unitPos, velocity, payload->ttl * 4, payload->damage,
+	                        payload->tail_size, payload->projectile_sprites, payload->impact_sfx);
 }
 
 bool AEquipment::canFire(float range)
-{ 
-	return type->type == AEquipmentType::Type::Weapon 
-		&& ammo > 0 
-		&& getPayloadType()->getRange() > range; 
+{
+	return type->type == AEquipmentType::Type::Weapon && ammo > 0 &&
+	       getPayloadType()->getRange() > range;
 };
 
 } // namespace OpenApoc

--- a/game/state/aequipment.cpp
+++ b/game/state/aequipment.cpp
@@ -146,12 +146,13 @@ sp<Projectile> AEquipment::fire(Vec3<float> target)
 	}
 
 	// FIXME: Apply accuracy
-	Vec3<float> velocity = target - unit->tileObject->getCenter();
-	velocity = glm::normalize(velocity) * VELOCITY_SCALE_BATTLE;
-	velocity *= payload->speed;
+	auto unitPos = unit->position + Vec3<float>{0.0f, 0.0f, (float)unit->getCurrentHeight() / 40.0f};
+	Vec3<float> velocity = target - unitPos;
+	velocity = glm::normalize(velocity);
+	velocity *= payload->speed * TICK_SCALE / 4;// I believe this is the correct formula
 
-	return mksp<Projectile>(unit, unit->tileObject->getCenter(), velocity,
-		payload->ttl * 4, payload->damage, payload->tail_size, payload->projectile_sprites);
+	return mksp<Projectile>(unit, unitPos, velocity,
+		payload->ttl * 4, payload->damage, payload->tail_size, payload->projectile_sprites, payload->impact_sfx);
 }
 
 bool AEquipment::canFire(float range)

--- a/game/state/aequipment.cpp
+++ b/game/state/aequipment.cpp
@@ -1,9 +1,11 @@
 #include "game/state/aequipment.h"
 #include "framework/framework.h"
+#include "game/state/city/projectile.h"
 #include "framework/logger.h"
 #include "game/state/agent.h"
 #include "game/state/rules/aequipment_type.h"
 #include "library/sp.h"
+#include "game/state/tileview/tileobject_battleunit.h"
 
 namespace OpenApoc
 {
@@ -32,14 +34,131 @@ int AEquipment::getAccuracy(AgentType::BodyState bodyState, BattleUnit::FireAimi
 	       (bodyState == AgentType::BodyState::Flying
 	            ? 90
 	            : (bodyState == AgentType::BodyState::Kneeling ? 110 : 100)) /
-	       100 / 100 / ((fireMode == BattleUnit::FireAimingMode::Auto
-	                         ? 4
-	                         : (fireMode == BattleUnit::FireAimingMode::Snap ? 2 : 1)));
+	       100 / 100  * (int)fireMode / 4;
 }
 
-void AEquipment::update(int)
+void AEquipment::stopFiring()
 {
-	// FIXME: Update equipment
+	weapon_fire_ticks_remaining = 0;
+	readyToFire = false;
 }
+
+void  AEquipment::startFiring(BattleUnit::FireAimingMode fireMode)
+{
+	if (ammo == 0)
+		return;
+	weapon_fire_ticks_remaining = getPayloadType()->fire_delay * (int)fireMode;
+	readyToFire = false;
+	aimingMode = fireMode;
+}
+
+void AEquipment::update(unsigned int ticks)
+{
+	// Recharge update
+	auto payload = getPayloadType();
+	if (payload->recharge > 0 && ammo < payload->max_ammo);
+	{
+		recharge_ticks_accumulated += ticks;
+	}
+	if (recharge_ticks_accumulated > TICKS_PER_RECHARGE)
+	{
+		recharge_ticks_accumulated = 0;
+		ammo += payload->recharge;
+		ammo = std::min(payload->max_ammo, ammo);
+	}
+
+	// Firing update
+	if (weapon_fire_ticks_remaining > 0)
+	{
+		if (weapon_fire_ticks_remaining > ticks)
+		{
+			weapon_fire_ticks_remaining -= ticks;
+		}
+		else
+		{
+			weapon_fire_ticks_remaining = 0;
+			readyToFire = true;
+		}
+	}
+	
+	// If firing - confirm we're still in business
+	if (isFiring())
+	{
+		switch (equippedSlotType)
+		{
+		// Check if we're still firing
+		case AgentEquipmentLayout::EquipmentSlotType::LeftHand:
+			if (ownerAgent->unit->weaponStatus != BattleUnit::WeaponStatus::FiringBothHands
+				&&ownerAgent->unit->weaponStatus != BattleUnit::WeaponStatus::FiringLeftHand)
+			{
+				stopFiring();
+			}
+			else if (ownerAgent->unit->fire_aiming_mode != aimingMode)
+			{
+				startFiring(ownerAgent->unit->fire_aiming_mode);
+			}
+			break;
+		case AgentEquipmentLayout::EquipmentSlotType::RightHand:
+			if (ownerAgent->unit->weaponStatus != BattleUnit::WeaponStatus::FiringBothHands
+				&&ownerAgent->unit->weaponStatus != BattleUnit::WeaponStatus::FiringRightHand)
+			{
+				stopFiring();
+			}
+			else if (ownerAgent->unit->fire_aiming_mode != aimingMode)
+			{
+				startFiring(ownerAgent->unit->fire_aiming_mode);
+			}
+			break;
+		// If weapon was dropped, we should stop firing
+		case AgentEquipmentLayout::EquipmentSlotType::None:
+		// If weapon was moved to any other slot from hands, stop firing
+		default:
+			stopFiring();
+			break;
+		}
+	}
+
+	// FIXME: Update equipment (grenades etc.)
+}
+
+sp<Projectile> AEquipment::fire(Vec3<float> target)
+{
+	if (this->type->type != AEquipmentType::Type::Weapon)
+	{
+		LogError("fire() called on non-Weapon");
+		return nullptr;
+	}
+	if (!readyToFire)
+	{
+		LogError("fire() called on non-ready Weapon");
+		return nullptr;
+	}
+	
+	readyToFire = false;
+	auto unit = ownerAgent->unit;
+	auto payload = getPayloadType();
+
+	ammo--;
+
+	if (payload->fire_sfx)
+	{
+		fw().soundBackend->playSample(payload->fire_sfx, unit->position);
+	}
+
+	// FIXME: Apply accuracy
+	Vec3<float> velocity = target - unit->tileObject->getCenter();
+	velocity = glm::normalize(velocity) * VELOCITY_SCALE_BATTLE;
+	velocity *= payload->speed;
+
+	return mksp<Projectile>(unit, unit->tileObject->getCenter(), velocity,
+		payload->ttl * 4, payload->damage, payload->tail_size, payload->projectile_sprites);
+}
+
+bool AEquipment::canFire(float range)
+{ 
+	return type->type == AEquipmentType::Type::Weapon 
+		&& ammo > 0 
+		&& getPayloadType()->getRange() > range; 
+};
 
 } // namespace OpenApoc

--- a/game/state/aequipment.h
+++ b/game/state/aequipment.h
@@ -1,9 +1,13 @@
 #pragma once
+#include "game/state/gametime.h"
 #include "game/state/agent.h"
 #include "game/state/battle/battleunit.h"
 #include "game/state/rules/aequipment_type.h"
 #include "library/sp.h"
 #include "library/vec.h"
+
+// Items recharge their recharge rate of ammo every 4 seconds
+#define TICKS_PER_RECHARGE 4 * TICKS_PER_SECOND
 
 namespace OpenApoc
 {
@@ -20,23 +24,35 @@ class AEquipment
 	StateRef<AEquipmentType> type;
 	// Type of loaded ammunition
 	StateRef<AEquipmentType> payloadType;
+	// Function to simplify getting payload for weapons and grenades
 	StateRef<AEquipmentType> getPayloadType();
 
 	Vec2<int> equippedPosition;
+	AgentEquipmentLayout::EquipmentSlotType equippedSlotType = AgentEquipmentLayout::EquipmentSlotType::None;
 	StateRef<Agent> ownerAgent;
+	
 	// Ammunition for weapons, protection for armor, charge for items
 	int ammo = 0;
 
-	bool aiming = false;
-	int weapon_fire_ticks_remaining = 0;
+	int recharge_ticks_accumulated = 0;
 
+	bool readyToFire = false;
+	int weapon_fire_ticks_remaining = 0;
+	BattleUnit::FireAimingMode aimingMode = BattleUnit::FireAimingMode::Aimed;
+	
 	int getAccuracy(AgentType::BodyState bodyState, BattleUnit::FireAimingMode fireMode);
+
+	bool isFiring() { return weapon_fire_ticks_remaining > 0 || readyToFire; };
+	bool canFire(float range = 0.0f);
+	void stopFiring();
+	void startFiring(BattleUnit::FireAimingMode fireMode);
+
 
 	// Following members are not serialized, but rather are set in initBattle method
 
 	wp<BattleItem> ownerItem;
 
-	void update(int ticks);
+	void update(unsigned int ticks);
 	/*
 	float getRange() const;
 	bool canFire() const;
@@ -44,7 +60,8 @@ class AEquipment
 	// Reload uses up to 'ammoAvailable' to reload the weapon. It returns the amount
 	// actually used.
 	int reload(int ammoAvailable);
-	sp<Projectile> fire(Vec3<float> target);
 	*/
+	sp<Projectile> fire(Vec3<float> target);
+	
 };
 } // namespace OpenApoc

--- a/game/state/aequipment.h
+++ b/game/state/aequipment.h
@@ -1,7 +1,7 @@
 #pragma once
-#include "game/state/gametime.h"
 #include "game/state/agent.h"
 #include "game/state/battle/battleunit.h"
+#include "game/state/gametime.h"
 #include "game/state/rules/aequipment_type.h"
 #include "library/sp.h"
 #include "library/vec.h"
@@ -28,9 +28,10 @@ class AEquipment
 	StateRef<AEquipmentType> getPayloadType();
 
 	Vec2<int> equippedPosition;
-	AgentEquipmentLayout::EquipmentSlotType equippedSlotType = AgentEquipmentLayout::EquipmentSlotType::None;
+	AgentEquipmentLayout::EquipmentSlotType equippedSlotType =
+	    AgentEquipmentLayout::EquipmentSlotType::None;
 	StateRef<Agent> ownerAgent;
-	
+
 	// Ammunition for weapons, protection for armor, charge for items
 	int ammo = 0;
 
@@ -39,14 +40,13 @@ class AEquipment
 	bool readyToFire = false;
 	int weapon_fire_ticks_remaining = 0;
 	BattleUnit::FireAimingMode aimingMode = BattleUnit::FireAimingMode::Aimed;
-	
+
 	int getAccuracy(AgentType::BodyState bodyState, BattleUnit::FireAimingMode fireMode);
 
 	bool isFiring() { return weapon_fire_ticks_remaining > 0 || readyToFire; };
 	bool canFire(float range = 0.0f);
 	void stopFiring();
 	void startFiring(BattleUnit::FireAimingMode fireMode);
-
 
 	// Following members are not serialized, but rather are set in initBattle method
 
@@ -62,6 +62,5 @@ class AEquipment
 	int reload(int ammoAvailable);
 	*/
 	sp<Projectile> fire(Vec3<float> target);
-	
 };
 } // namespace OpenApoc

--- a/game/state/agent.cpp
+++ b/game/state/agent.cpp
@@ -350,16 +350,23 @@ int Agent::getArmorValue(AgentType::BodyPart bodyPart) const
 	return type->armor.at(bodyPart);
 }
 
-bool Agent::canAddEquipment(Vec2<int> pos, StateRef<AEquipmentType> type) const
+AgentEquipmentLayout::EquipmentSlotType Agent::canAddEquipment(Vec2<int> pos, StateRef<AEquipmentType> type) const
 {
 	Vec2<int> slotOrigin;
 	bool slotFound = false;
 	bool slotIsArmor = false;
+	AgentEquipmentLayout::EquipmentSlotType slotType;
 	// Check the slot this occupies hasn't already got something there
 	for (auto &slot : this->type->equipment_layout->slots)
 	{
 		if (slot.bounds.within(pos))
 		{
+			// None is not a valid equipment slot
+			if (slot.type == AgentEquipmentLayout::EquipmentSlotType::None)
+			{
+				LogError("Agent has equipment slot \"None\"??");
+				return AgentEquipmentLayout::EquipmentSlotType::None;
+			}
 			// If we are equipping into an armor slot, ensure the item being equipped is armor
 			if (slot.type == AgentEquipmentLayout::EquipmentSlotType::ArmorBody ||
 			    slot.type == AgentEquipmentLayout::EquipmentSlotType::ArmorLegs ||
@@ -372,15 +379,16 @@ bool Agent::canAddEquipment(Vec2<int> pos, StateRef<AEquipmentType> type) const
 					break;
 			}
 			slotOrigin = slot.bounds.p0;
+			slotType = slot.type;
 			slotFound = true;
-
+			
 			break;
 		}
 	}
 	// If this was not within a slot fail
 	if (!slotFound)
 	{
-		return false;
+		return AgentEquipmentLayout::EquipmentSlotType::None;
 	}
 
 	// Check that the equipment doesn't overlap with any other and doesn't
@@ -432,7 +440,7 @@ bool Agent::canAddEquipment(Vec2<int> pos, StateRef<AEquipmentType> type) const
 			// Something is already in that slot, fail
 			if (otherEquipment->equippedPosition == slotOrigin)
 			{
-				return false;
+				return AgentEquipmentLayout::EquipmentSlotType::None;
 			}
 			Rect<int> otherBounds{otherEquipment->equippedPosition,
 			                      otherEquipment->equippedPosition +
@@ -442,20 +450,26 @@ bool Agent::canAddEquipment(Vec2<int> pos, StateRef<AEquipmentType> type) const
 				LogInfo(
 				    "Equipping \"%s\" on \"%s\" at {%d,%d} failed: Intersects with other equipment",
 				    type->name.cStr(), this->name.cStr(), pos.x, pos.y);
-				return false;
+				return AgentEquipmentLayout::EquipmentSlotType::None;
 			}
 		}
 	}
 
-	return true;
+	return slotType;
 }
 
+// If type is null we look for any slot, if type is not null we look for slot that can fit the type
 Vec2<int> Agent::findFirstSlotByType(AgentEquipmentLayout::EquipmentSlotType slotType, StateRef<AEquipmentType> type)
 {
 	Vec2<int> pos = { -1, 0 };
+	if (slotType == AgentEquipmentLayout::EquipmentSlotType::None)
+	{
+		LogError("Trying to find equipment slot None??");
+		return pos;
+	}
 	for (auto &slot : this->type->equipment_layout->slots)
 	{
-		if (slot.type == slotType && (!type || canAddEquipment(slot.bounds.p0, type)))
+		if (slot.type == slotType && (!type || canAddEquipment(slot.bounds.p0, type) != AgentEquipmentLayout::EquipmentSlotType::None))
 		{
 			pos = slot.bounds.p0;
 			break;
@@ -470,7 +484,7 @@ void Agent::addEquipmentByType(GameState &state, StateRef<AEquipmentType> type)
 	bool slotFound = false;
 	for (auto &slot : this->type->equipment_layout->slots)
 	{
-		if (canAddEquipment(slot.bounds.p0, type))
+		if (canAddEquipment(slot.bounds.p0, type) != AgentEquipmentLayout::EquipmentSlotType::None)
 		{
 			pos = slot.bounds.p0;
 			slotFound = true;
@@ -490,6 +504,11 @@ void Agent::addEquipmentByType(GameState &state, StateRef<AEquipmentType> type)
 void Agent::addEquipmentByType(GameState &state, StateRef<AEquipmentType> type,
                          AgentEquipmentLayout::EquipmentSlotType slotType)
 {
+	if (slotType == AgentEquipmentLayout::EquipmentSlotType::None)
+	{
+		LogError("Trying to add equipment to slot None??");
+		return;
+	}
 	Vec2<int> pos = findFirstSlotByType(slotType, type);
 	if (pos.x == -1)
 	{
@@ -503,7 +522,7 @@ void Agent::addEquipmentByType(GameState &state, StateRef<AEquipmentType> type,
 
 void Agent::addEquipmentByType(GameState &state, Vec2<int> pos, StateRef<AEquipmentType> type)
 {
-	if (!this->canAddEquipment(pos, type))
+	if (this->canAddEquipment(pos, type) == AgentEquipmentLayout::EquipmentSlotType::None)
 	{
 		LogError("Trying to add \"%s\" at {%d,%d} on agent \"%s\" failed", type.id.cStr(), pos.x,
 			pos.y, this->name.cStr());
@@ -525,6 +544,11 @@ void Agent::addEquipmentByType(GameState &state, Vec2<int> pos, StateRef<AEquipm
 void Agent::addEquipment(GameState &state, sp<AEquipment> object,
 	AgentEquipmentLayout::EquipmentSlotType slotType)
 {
+	if (slotType == AgentEquipmentLayout::EquipmentSlotType::None)
+	{
+		LogError("Trying to add equipment to slot None??");
+		return;
+	}
 	Vec2<int> pos = findFirstSlotByType(slotType, object->type);
 	if (pos.x == -1)
 	{
@@ -539,7 +563,8 @@ void Agent::addEquipment(GameState &state, sp<AEquipment> object,
 
 void Agent::addEquipment(GameState &state, Vec2<int> pos, sp<AEquipment> object)
 {
-	if (!this->canAddEquipment(pos, object->type))
+	auto slotType = this->canAddEquipment(pos, object->type);
+	if (slotType == AgentEquipmentLayout::EquipmentSlotType::None)
 	{
 		LogError("Trying to add \"%s\" at {%d,%d} on agent  \"%s\" failed", object->type.id.cStr(),
 		         pos.x, pos.y, this->name.cStr());
@@ -548,6 +573,15 @@ void Agent::addEquipment(GameState &state, Vec2<int> pos, sp<AEquipment> object)
 	LogInfo("Equipped \"%s\" with equipment \"%s\"", this->name.cStr(), object->type->name.cStr());
 	object->equippedPosition = pos;
 	object->ownerAgent = StateRef<Agent>(&state, shared_from_this());
+	object->equippedSlotType = slotType;
+	if (slotType == AgentEquipmentLayout::EquipmentSlotType::RightHand)
+	{
+		rightHandItem = object;
+	}
+	if (slotType == AgentEquipmentLayout::EquipmentSlotType::LeftHand)
+	{
+		leftHandItem = object;
+	}
 	this->equipment.emplace_back(object);
 	updateSpeed();
 }
@@ -555,6 +589,19 @@ void Agent::addEquipment(GameState &state, Vec2<int> pos, sp<AEquipment> object)
 void Agent::removeEquipment(sp<AEquipment> object)
 {
 	this->equipment.remove(object);
+	if (unit)
+	{
+		unit->updateDisplayedItem();
+	}
+	if (object->equippedSlotType == AgentEquipmentLayout::EquipmentSlotType::RightHand)
+	{
+		rightHandItem = nullptr;
+	}
+	if (object->equippedSlotType == AgentEquipmentLayout::EquipmentSlotType::LeftHand)
+	{
+		leftHandItem = nullptr;
+	}
+	object->equippedSlotType = AgentEquipmentLayout::EquipmentSlotType::None;
 	updateSpeed();
 }
 
@@ -570,23 +617,51 @@ StateRef<BattleUnitAnimationPack> Agent::getAnimationPack() const
 	return type->animation_packs[appearance];
 }
 
-StateRef<AEquipmentType> Agent::getDominantItemInHands() const
+StateRef<AEquipmentType> Agent::getDominantItemInHands(StateRef<AEquipmentType> itemLastFired) const
 {
 	sp<AEquipment> e1 = getFirstItemInSlot(AgentEquipmentLayout::EquipmentSlotType::RightHand);
 	sp<AEquipment> e2 = getFirstItemInSlot(AgentEquipmentLayout::EquipmentSlotType::LeftHand);
-	if (e1 && e1->type->two_handed)
-		return {e1->type};
-	if (e2 && e2->type->two_handed)
-		return {e2->type};
-	if (e1)
+	// If there is only one item - return it, if none - return nothing
+	if (!e1 && !e2)
+		return nullptr;
+	else if (e1 && !e2)
 		return e1->type;
-	if (e2)
+	else if (e2 && !e1)
 		return e2->type;
-	return nullptr;
+	// If item was last fired and still in hands - return it
+	if (itemLastFired)
+	{
+		if (e1 && e1->type == itemLastFired)
+			return e1->type;
+		if (e2 && e2->type == itemLastFired)
+			return e2->type;
+	}
+	// Calculate item priorities: Two-Handed >> Weapon >> Usable Item >> Others
+	int e1Priority = e1->type->two_handed ? 3 :
+		(e1->type->type == AEquipmentType::Type::Weapon ? 2 :
+		(e1->type->type != AEquipmentType::Type::Ammo
+			&& e1->type->type != AEquipmentType::Type::Armor
+			&& e1->type->type != AEquipmentType::Type::Loot) ? 1 : 0);
+	int e2Priority = e2->type->two_handed ? 3 :
+		(e2->type->type == AEquipmentType::Type::Weapon ? 2 :
+		(e2->type->type != AEquipmentType::Type::Ammo
+			&& e2->type->type != AEquipmentType::Type::Armor
+			&& e2->type->type != AEquipmentType::Type::Loot) ? 1 : 0);
+	// Right hand has priority in case of a tie
+	if (e1Priority >= e2Priority)
+		return e2->type;
+	return e1->type;
 }
 
-sp<AEquipment> Agent::getFirstItemInSlot(AgentEquipmentLayout::EquipmentSlotType type) const
+sp<AEquipment> Agent::getFirstItemInSlot(AgentEquipmentLayout::EquipmentSlotType type, bool lazy) const
 {
+	if (lazy)
+	{
+		if (type == AgentEquipmentLayout::EquipmentSlotType::RightHand)
+			return rightHandItem;
+		if (type == AgentEquipmentLayout::EquipmentSlotType::LeftHand)
+			return leftHandItem;
+	}
 	for (auto e : equipment)
 	{
 		for (auto s : this->type->equipment_layout->slots)

--- a/game/state/agent.cpp
+++ b/game/state/agent.cpp
@@ -269,7 +269,7 @@ StateRef<Agent> AgentGenerator::createAgent(GameState &state, StateRef<Organisat
 		if (t->type == AEquipmentType::Type::Ammo)
 		{
 			agent->addEquipmentByType(state, {&state, t->id},
-			                    AgentEquipmentLayout::EquipmentSlotType::General);
+			                          AgentEquipmentLayout::EquipmentSlotType::General);
 		}
 		else
 		{
@@ -350,7 +350,8 @@ int Agent::getArmorValue(AgentType::BodyPart bodyPart) const
 	return type->armor.at(bodyPart);
 }
 
-AgentEquipmentLayout::EquipmentSlotType Agent::canAddEquipment(Vec2<int> pos, StateRef<AEquipmentType> type) const
+AgentEquipmentLayout::EquipmentSlotType Agent::canAddEquipment(Vec2<int> pos,
+                                                               StateRef<AEquipmentType> type) const
 {
 	Vec2<int> slotOrigin;
 	bool slotFound = false;
@@ -381,7 +382,7 @@ AgentEquipmentLayout::EquipmentSlotType Agent::canAddEquipment(Vec2<int> pos, St
 			slotOrigin = slot.bounds.p0;
 			slotType = slot.type;
 			slotFound = true;
-			
+
 			break;
 		}
 	}
@@ -459,9 +460,10 @@ AgentEquipmentLayout::EquipmentSlotType Agent::canAddEquipment(Vec2<int> pos, St
 }
 
 // If type is null we look for any slot, if type is not null we look for slot that can fit the type
-Vec2<int> Agent::findFirstSlotByType(AgentEquipmentLayout::EquipmentSlotType slotType, StateRef<AEquipmentType> type)
+Vec2<int> Agent::findFirstSlotByType(AgentEquipmentLayout::EquipmentSlotType slotType,
+                                     StateRef<AEquipmentType> type)
 {
-	Vec2<int> pos = { -1, 0 };
+	Vec2<int> pos = {-1, 0};
 	if (slotType == AgentEquipmentLayout::EquipmentSlotType::None)
 	{
 		LogError("Trying to find equipment slot None??");
@@ -469,7 +471,9 @@ Vec2<int> Agent::findFirstSlotByType(AgentEquipmentLayout::EquipmentSlotType slo
 	}
 	for (auto &slot : this->type->equipment_layout->slots)
 	{
-		if (slot.type == slotType && (!type || canAddEquipment(slot.bounds.p0, type) != AgentEquipmentLayout::EquipmentSlotType::None))
+		if (slot.type == slotType && (!type ||
+		                              canAddEquipment(slot.bounds.p0, type) !=
+		                                  AgentEquipmentLayout::EquipmentSlotType::None))
 		{
 			pos = slot.bounds.p0;
 			break;
@@ -502,7 +506,7 @@ void Agent::addEquipmentByType(GameState &state, StateRef<AEquipmentType> type)
 }
 
 void Agent::addEquipmentByType(GameState &state, StateRef<AEquipmentType> type,
-                         AgentEquipmentLayout::EquipmentSlotType slotType)
+                               AgentEquipmentLayout::EquipmentSlotType slotType)
 {
 	if (slotType == AgentEquipmentLayout::EquipmentSlotType::None)
 	{
@@ -525,7 +529,7 @@ void Agent::addEquipmentByType(GameState &state, Vec2<int> pos, StateRef<AEquipm
 	if (this->canAddEquipment(pos, type) == AgentEquipmentLayout::EquipmentSlotType::None)
 	{
 		LogError("Trying to add \"%s\" at {%d,%d} on agent \"%s\" failed", type.id.cStr(), pos.x,
-			pos.y, this->name.cStr());
+		         pos.y, this->name.cStr());
 	}
 	auto equipment = mksp<AEquipment>();
 	equipment->type = type;
@@ -542,7 +546,7 @@ void Agent::addEquipmentByType(GameState &state, Vec2<int> pos, StateRef<AEquipm
 }
 
 void Agent::addEquipment(GameState &state, sp<AEquipment> object,
-	AgentEquipmentLayout::EquipmentSlotType slotType)
+                         AgentEquipmentLayout::EquipmentSlotType slotType)
 {
 	if (slotType == AgentEquipmentLayout::EquipmentSlotType::None)
 	{
@@ -553,13 +557,12 @@ void Agent::addEquipment(GameState &state, sp<AEquipment> object,
 	if (pos.x == -1)
 	{
 		LogError("Trying to add \"%s\" on agent \"%s\" failed: no valid slot found", type.id.cStr(),
-			this->name.cStr());
+		         this->name.cStr());
 		return;
 	}
 
 	this->addEquipment(state, pos, object);
 }
-
 
 void Agent::addEquipment(GameState &state, Vec2<int> pos, sp<AEquipment> object)
 {
@@ -637,23 +640,30 @@ StateRef<AEquipmentType> Agent::getDominantItemInHands(StateRef<AEquipmentType> 
 			return e2->type;
 	}
 	// Calculate item priorities: Two-Handed >> Weapon >> Usable Item >> Others
-	int e1Priority = e1->type->two_handed ? 3 :
-		(e1->type->type == AEquipmentType::Type::Weapon ? 2 :
-		(e1->type->type != AEquipmentType::Type::Ammo
-			&& e1->type->type != AEquipmentType::Type::Armor
-			&& e1->type->type != AEquipmentType::Type::Loot) ? 1 : 0);
-	int e2Priority = e2->type->two_handed ? 3 :
-		(e2->type->type == AEquipmentType::Type::Weapon ? 2 :
-		(e2->type->type != AEquipmentType::Type::Ammo
-			&& e2->type->type != AEquipmentType::Type::Armor
-			&& e2->type->type != AEquipmentType::Type::Loot) ? 1 : 0);
+	int e1Priority =
+	    e1->type->two_handed ? 3 : (e1->type->type == AEquipmentType::Type::Weapon
+	                                    ? 2
+	                                    : (e1->type->type != AEquipmentType::Type::Ammo &&
+	                                       e1->type->type != AEquipmentType::Type::Armor &&
+	                                       e1->type->type != AEquipmentType::Type::Loot)
+	                                          ? 1
+	                                          : 0);
+	int e2Priority =
+	    e2->type->two_handed ? 3 : (e2->type->type == AEquipmentType::Type::Weapon
+	                                    ? 2
+	                                    : (e2->type->type != AEquipmentType::Type::Ammo &&
+	                                       e2->type->type != AEquipmentType::Type::Armor &&
+	                                       e2->type->type != AEquipmentType::Type::Loot)
+	                                          ? 1
+	                                          : 0);
 	// Right hand has priority in case of a tie
 	if (e1Priority >= e2Priority)
 		return e2->type;
 	return e1->type;
 }
 
-sp<AEquipment> Agent::getFirstItemInSlot(AgentEquipmentLayout::EquipmentSlotType type, bool lazy) const
+sp<AEquipment> Agent::getFirstItemInSlot(AgentEquipmentLayout::EquipmentSlotType type,
+                                         bool lazy) const
 {
 	if (lazy)
 	{

--- a/game/state/agent.h
+++ b/game/state/agent.h
@@ -258,18 +258,20 @@ class Agent : public StateObject<Agent>, public std::enable_shared_from_this<Age
 
 	std::list<sp<AEquipment>> equipment;
 	// Returns None if cannot add
-	AgentEquipmentLayout::EquipmentSlotType canAddEquipment(Vec2<int> pos, StateRef<AEquipmentType> type) const;
-	Vec2<int> findFirstSlotByType(AgentEquipmentLayout::EquipmentSlotType slotType, StateRef<AEquipmentType> type = nullptr);
+	AgentEquipmentLayout::EquipmentSlotType canAddEquipment(Vec2<int> pos,
+	                                                        StateRef<AEquipmentType> type) const;
+	Vec2<int> findFirstSlotByType(AgentEquipmentLayout::EquipmentSlotType slotType,
+	                              StateRef<AEquipmentType> type = nullptr);
 	// Add equipment by type to the first available slot of any type
 	void addEquipmentByType(GameState &state, StateRef<AEquipmentType> type);
 	// Add equipment to the first available slot of a specific type
 	void addEquipmentByType(GameState &state, StateRef<AEquipmentType> type,
-	                  AgentEquipmentLayout::EquipmentSlotType slotType);
+	                        AgentEquipmentLayout::EquipmentSlotType slotType);
 	// Add equipment by type to a specific position
 	void addEquipmentByType(GameState &state, Vec2<int> pos, StateRef<AEquipmentType> type);
 	// Add equipment to the first available slot of a specific type
 	void addEquipment(GameState &state, sp<AEquipment> object,
-		AgentEquipmentLayout::EquipmentSlotType slotType);
+	                  AgentEquipmentLayout::EquipmentSlotType slotType);
 	// Add equipment to a specific position
 	void addEquipment(GameState &state, Vec2<int> pos, sp<AEquipment> object);
 	void removeEquipment(sp<AEquipment> object);
@@ -277,14 +279,17 @@ class Agent : public StateObject<Agent>, public std::enable_shared_from_this<Age
 	bool canRun() { return modified_stats.canRun(); }
 
 	StateRef<BattleUnitAnimationPack> getAnimationPack() const;
-	// If item was fired before, it should be passed here, and it will remain dominant unless it was removed
-	StateRef<AEquipmentType> getDominantItemInHands(StateRef<AEquipmentType> itemLastFired = nullptr) const;
-	sp<AEquipment> getFirstItemInSlot(AgentEquipmentLayout::EquipmentSlotType type, bool lazy = true) const;
+	// If item was fired before, it should be passed here, and it will remain dominant unless it was
+	// removed
+	StateRef<AEquipmentType>
+	getDominantItemInHands(StateRef<AEquipmentType> itemLastFired = nullptr) const;
+	sp<AEquipment> getFirstItemInSlot(AgentEquipmentLayout::EquipmentSlotType type,
+	                                  bool lazy = true) const;
 	StateRef<BattleUnitImagePack> getImagePack(AgentType::BodyPart bodyPart) const;
 
 	// Following members are not serialized, but rather are set up in the initBattle method
-	
-	sp<AEquipment> leftHandItem; // Left hand item, frequently accessed so will be stored here
+
+	sp<AEquipment> leftHandItem;  // Left hand item, frequently accessed so will be stored here
 	sp<AEquipment> rightHandItem; // Left hand item, frequently accessed so will be stored here
 };
 

--- a/game/state/agent.h
+++ b/game/state/agent.h
@@ -60,6 +60,7 @@ class AgentEquipmentLayout : public StateObject<AgentEquipmentLayout>
   public:
 	enum class EquipmentSlotType
 	{
+		None, // Used for equipment dropped by agent
 		General,
 		ArmorBody,
 		ArmorLegs,
@@ -253,8 +254,11 @@ class Agent : public StateObject<Agent>, public std::enable_shared_from_this<Age
 
 	bool assigned_to_lab = false;
 
+	StateRef<BattleUnit> unit;
+
 	std::list<sp<AEquipment>> equipment;
-	bool canAddEquipment(Vec2<int> pos, StateRef<AEquipmentType> type) const;
+	// Returns None if cannot add
+	AgentEquipmentLayout::EquipmentSlotType canAddEquipment(Vec2<int> pos, StateRef<AEquipmentType> type) const;
 	Vec2<int> findFirstSlotByType(AgentEquipmentLayout::EquipmentSlotType slotType, StateRef<AEquipmentType> type = nullptr);
 	// Add equipment by type to the first available slot of any type
 	void addEquipmentByType(GameState &state, StateRef<AEquipmentType> type);
@@ -273,12 +277,15 @@ class Agent : public StateObject<Agent>, public std::enable_shared_from_this<Age
 	bool canRun() { return modified_stats.canRun(); }
 
 	StateRef<BattleUnitAnimationPack> getAnimationPack() const;
-	StateRef<AEquipmentType> getDominantItemInHands() const;
-	sp<AEquipment> getFirstItemInSlot(AgentEquipmentLayout::EquipmentSlotType type) const;
+	// If item was fired before, it should be passed here, and it will remain dominant unless it was removed
+	StateRef<AEquipmentType> getDominantItemInHands(StateRef<AEquipmentType> itemLastFired = nullptr) const;
+	sp<AEquipment> getFirstItemInSlot(AgentEquipmentLayout::EquipmentSlotType type, bool lazy = true) const;
 	StateRef<BattleUnitImagePack> getImagePack(AgentType::BodyPart bodyPart) const;
 
 	// Following members are not serialized, but rather are set up in the initBattle method
-	sp<BattleUnit> unit;
+	
+	sp<AEquipment> leftHandItem; // Left hand item, frequently accessed so will be stored here
+	sp<AEquipment> rightHandItem; // Left hand item, frequently accessed so will be stored here
 };
 
 class AgentGenerator

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -236,6 +236,11 @@ void Battle::update(GameState &state, unsigned int ticks)
 		{
 			// FIXME: Handle collision
 			this->projectiles.erase(c.projectile);
+			if (c.projectile->impactSfx)
+			{
+				fw().soundBackend->playSample(c.projectile->impactSfx, c.position);
+			}
+			
 			// FIXME: Get doodad from weapon definition?
 			auto doodad = this->placeDoodad({&state, "DOODAD_EXPLOSION_0"}, c.position);
 

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -67,7 +67,7 @@ Battle::~Battle()
 	this->map_parts.clear();
 	for (auto &u : this->units)
 	{
-		u->agent->unit = nullptr;
+		u.second->agent->unit = nullptr;
 	}
 	for (auto &s : this->items)
 	{
@@ -111,8 +111,11 @@ void Battle::initBattle(GameState &state)
 	}
 	for (auto &o : this->units)
 	{
-		o->battle = stt;
-		o->agent->unit = o->shared_from_this();
+		o.second->battle = stt;
+		if (o.second->focusUnit)
+		{
+			o.second->focusUnit->focusedByUnits.push_back(o.second);
+		}
 	}
 	if (forces.size() == 0)
 	{
@@ -128,7 +131,7 @@ void Battle::initBattle(GameState &state)
 		// Place units into squads directly to their positions
 		for (auto &u : this->units)
 		{
-			forces[u->owner].squads[u->squadNumber].units[u->squadPosition] = u;
+			forces[u.second->owner].squads[u.second->squadNumber].units[u.second->squadPosition] = u.second;
 		}
 		// Trim nullptrs from squad units
 		for (auto &o : this->participants)
@@ -185,11 +188,11 @@ void Battle::initMap()
 	}
 	for (auto &u : this->units)
 	{
-		if (u->destroyed || u->retreated)
+		if (u.second->destroyed || u.second->retreated)
 		{
 			continue;
 		}
-		this->map->addObjectToMap(u);
+		this->map->addObjectToMap(u.second);
 	}
 	for (auto &p : this->projectiles)
 	{
@@ -209,6 +212,12 @@ sp<Doodad> Battle::placeDoodad(StateRef<DoodadType> type, Vec3<float> position)
 	return doodad;
 }
 
+void Battle::addUnit(sp<BattleUnit> unit)
+{
+	unit->id = UString::format("%s%d", BattleUnit::getPrefix(), (int)units.size());
+	units[unit->id] = unit;
+}
+
 void Battle::update(GameState &state, unsigned int ticks)
 {
 	TRACE_FN_ARGS1("ticks", Strings::fromInteger(static_cast<int>(ticks)));
@@ -223,6 +232,7 @@ void Battle::update(GameState &state, unsigned int ticks)
 	{
 		auto &p = *it++;
 		auto c = p->checkProjectileCollision(*map);
+		if (c)
 		{
 			// FIXME: Handle collision
 			this->projectiles.erase(c.projectile);
@@ -280,7 +290,7 @@ void Battle::update(GameState &state, unsigned int ticks)
 	Trace::start("Battle::update::units->update");
 	for (auto &o : this->units)
 	{
-		o->update(state, ticks);
+		o.second->update(state, ticks);
 	}
 	Trace::end("Battle::update::units->update");
 	Trace::start("Battle::update::doodads->update");
@@ -301,13 +311,13 @@ void Battle::beginTurn()
 	
 	LogWarning("Implement beginning turn!");
 
-	for (auto u : units)
+	for (auto &u : units)
 	{
-		if (u->owner != currentActiveOrganisation)
+		if (u.second->owner != currentActiveOrganisation)
 		{
 			continue;
 		}
-		u->agent->modified_stats.restoreTU();
+		u.second->agent->modified_stats.restoreTU();
 	}
 }
 
@@ -850,8 +860,9 @@ void Battle::enterBattle(GameState &state)
 	// Turn units towards map centre
 	// Also make sure they're facing in a valid direction
 	// And stand in a valid pose
-	for (auto u : b->units)
+	for (auto p : b->units)
 	{
+		auto u = p.second;
 		int x_diff = (int)(u->position.x - b->size.x / 2);
 		int y_diff = (int)(u->position.y - b->size.y / 2);
 		if (std::abs(x_diff) > std::abs(y_diff))
@@ -1010,8 +1021,9 @@ void Battle::loadImagePacks(GameState &state)
 	}
 	// Find out all image packs used by map's units and items
 	std::set<UString> imagePacks;
-	for (auto &bu : units)
+	for (auto &p : units)
 	{
+		auto &bu = p.second;
 		{
 			auto packName = BattleUnitImagePack::getNameFromID(bu->agent->type->shadow_pack.id);
 			if (imagePacks.find(packName) == imagePacks.end())
@@ -1089,9 +1101,9 @@ void Battle::loadAnimationPacks(GameState &state)
 	}
 	// Find out all animation packs used by units
 	std::set<UString> animationPacks;
-	for (auto &bu : units)
+	for (auto &u : units)
 	{
-		for (auto &ap : bu->agent->type->animation_packs)
+		for (auto &ap : u.second->agent->type->animation_packs)
 		{
 			auto packName = BattleUnitAnimationPack::getNameFromID(ap.id);
 			if (animationPacks.find(packName) == animationPacks.end())

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -28,7 +28,7 @@
 #include <unordered_map>
 
 #ifdef _MSC_VER
-#pragma warning (push, 1)
+#pragma warning(push, 1)
 #pragma warning(disable : 4503)
 #endif
 
@@ -131,7 +131,8 @@ void Battle::initBattle(GameState &state)
 		// Place units into squads directly to their positions
 		for (auto &u : this->units)
 		{
-			forces[u.second->owner].squads[u.second->squadNumber].units[u.second->squadPosition] = u.second;
+			forces[u.second->owner].squads[u.second->squadNumber].units[u.second->squadPosition] =
+			    u.second;
 		}
 		// Trim nullptrs from squad units
 		for (auto &o : this->participants)
@@ -240,7 +241,7 @@ void Battle::update(GameState &state, unsigned int ticks)
 			{
 				fw().soundBackend->playSample(c.projectile->impactSfx, c.position);
 			}
-			
+
 			// FIXME: Get doodad from weapon definition?
 			auto doodad = this->placeDoodad({&state, "DOODAD_EXPLOSION_0"}, c.position);
 
@@ -313,7 +314,7 @@ void Battle::beginTurn()
 		LogError("beginTurn called in real time?");
 		return;
 	}
-	
+
 	LogWarning("Implement beginning turn!");
 
 	for (auto &u : units)
@@ -1145,5 +1146,5 @@ void Battle::unloadAnimationPacks(GameState &state)
 } // namespace OpenApoc
 
 #ifdef _MSC_VER
-#pragma warning (pop)
+#pragma warning(pop)
 #endif

--- a/game/state/battle/battle.h
+++ b/game/state/battle/battle.h
@@ -80,7 +80,7 @@ class Battle : public std::enable_shared_from_this<Battle>
 
 	std::list<sp<BattleMapPart>> map_parts;
 	std::list<sp<BattleItem>> items;
-	std::list<sp<BattleUnit>> units;
+	StateRefMap<BattleUnit> units;
 	std::list<sp<Doodad>> doodads;
 	std::set<sp<Projectile>> projectiles;
 	std::vector<sp<BattleDoor>> doors;
@@ -116,6 +116,9 @@ class Battle : public std::enable_shared_from_this<Battle>
 
 	void update(GameState &state, unsigned int ticks);
 	sp<Doodad> placeDoodad(StateRef<DoodadType> type, Vec3<float> position);
+
+	// Adds unit, setting it's id
+	void addUnit(sp<BattleUnit> unit);
 
 	// Turn based functions
 

--- a/game/state/battle/battlecommonimagelist.h
+++ b/game/state/battle/battlecommonimagelist.h
@@ -13,5 +13,6 @@ class BattleCommonImageList
   public:
 	std::vector<sp<Image>> strategyImages;
 	sp<Image> loadingImage;
+	std::vector<sp<Image>> focusArrows;
 };
 }

--- a/game/state/battle/battleitem.cpp
+++ b/game/state/battle/battleitem.cpp
@@ -59,6 +59,17 @@ void BattleItem::setPosition(const Vec3<float> &pos)
 	}
 }
 
+Collision BattleItem::checkItemCollision(Vec3<float> previousPosition, Vec3<float> nextPosition)
+{
+	Collision c = tileObject->map.findCollision(previousPosition, nextPosition, {});
+	if (c && ownerInvulnerableTicks > 0 && c.obj->getType() == TileObject::Type::Unit &&
+		item->ownerAgent->unit == std::static_pointer_cast<TileObjectBattleUnit>(c.obj)->getUnit())
+	{
+		return{};
+	}
+	return c;
+}
+
 void BattleItem::update(GameState &state, unsigned int ticks)
 {
 	if (supported)
@@ -66,6 +77,10 @@ void BattleItem::update(GameState &state, unsigned int ticks)
 		return;
 	}
 
+	if (ownerInvulnerableTicks > 0)
+	{
+		ownerInvulnerableTicks -= ticks;
+	}
 	int remainingTicks = ticks;
 
 	auto previousPosition = position;
@@ -82,7 +97,7 @@ void BattleItem::update(GameState &state, unsigned int ticks)
 	// Check if new position is valid
 	// FIXME: Collide with units but not with us
 	bool collision = false;
-	auto c = tileObject->map.findCollision(previousPosition, newPosition, {}, item->ownerAgent->unit->tileObject);
+	auto c = checkItemCollision(previousPosition, newPosition);
 	if (c)
 	{
 		collision = true;

--- a/game/state/battle/battleitem.cpp
+++ b/game/state/battle/battleitem.cpp
@@ -6,9 +6,9 @@
 #include "game/state/gamestate.h"
 #include "game/state/tileview/collision.h"
 #include "game/state/tileview/tile.h"
-#include "game/state/tileview/tileobject_battleunit.h"
 #include "game/state/tileview/tileobject_battleitem.h"
 #include "game/state/tileview/tileobject_battlemappart.h"
+#include "game/state/tileview/tileobject_battleunit.h"
 #include "game/state/tileview/tileobject_shadow.h"
 #include <cmath>
 
@@ -63,9 +63,9 @@ Collision BattleItem::checkItemCollision(Vec3<float> previousPosition, Vec3<floa
 {
 	Collision c = tileObject->map.findCollision(previousPosition, nextPosition, {});
 	if (c && ownerInvulnerableTicks > 0 && c.obj->getType() == TileObject::Type::Unit &&
-		item->ownerAgent->unit == std::static_pointer_cast<TileObjectBattleUnit>(c.obj)->getUnit())
+	    item->ownerAgent->unit == std::static_pointer_cast<TileObjectBattleUnit>(c.obj)->getUnit())
 	{
-		return{};
+		return {};
 	}
 	return c;
 }
@@ -91,8 +91,9 @@ void BattleItem::update(GameState &state, unsigned int ticks)
 		velocity.z -= FALLING_ACCELERATION_ITEM;
 		newPosition += this->velocity / (float)TICK_SCALE / VELOCITY_SCALE_BATTLE;
 	}
-	
-	auto prevPrevPos = previousPosition - (float)ticks * this->velocity / (float)TICK_SCALE / VELOCITY_SCALE_BATTLE;
+
+	auto prevPrevPos = previousPosition -
+	                   (float)ticks * this->velocity / (float)TICK_SCALE / VELOCITY_SCALE_BATTLE;
 
 	// Check if new position is valid
 	// FIXME: Collide with units but not with us
@@ -104,34 +105,36 @@ void BattleItem::update(GameState &state, unsigned int ticks)
 		// If colliding with anything but ground, bounce back once
 		switch (c.obj->getType())
 		{
-		case TileObject::Type::Unit:
-		case TileObject::Type::LeftWall:
-		case TileObject::Type::RightWall:
-		case TileObject::Type::Feature:
-			if (!bounced)
+			case TileObject::Type::Unit:
+			case TileObject::Type::LeftWall:
+			case TileObject::Type::RightWall:
+			case TileObject::Type::Feature:
+				if (!bounced)
+				{
+					// If bounced do not try to find support this time
+					collision = false;
+					bounced = true;
+					newPosition = previousPosition;
+					velocity.x = -velocity.x / 4;
+					velocity.y = -velocity.y / 4;
+					velocity.z = std::abs(velocity.z / 4);
+				}
+				else
+				{
+					// Let item fall so that it can collide with scenery if falling on top of it
+					newPosition = {previousPosition.x, previousPosition.y,
+					               std::min(newPosition.z, previousPosition.z)};
+				}
+				break;
+			case TileObject::Type::Ground:
 			{
-				// If bounced do not try to find support this time
-				collision = false;
-				bounced = true;
-				newPosition = previousPosition;
-				velocity.x = -velocity.x / 4;
-				velocity.y = -velocity.y / 4;
-				velocity.z = std::abs(velocity.z / 4);
-			}
-			else
-			{
-				// Let item fall so that it can collide with scenery if falling on top of it
-				newPosition = { previousPosition.x, previousPosition.y, std::min(newPosition.z, previousPosition.z) };
-			}
-			break;
-		case TileObject::Type::Ground:
-			{
-				setPosition({ c.position.x, c.position.y, c.position.z });
+				setPosition({c.position.x, c.position.y, c.position.z});
 				if (findSupport(true, true))
 				{
 					return;
 				}
-				// Some objects have buggy voxelmaps and items collide with them but no support is given
+				// Some objects have buggy voxelmaps and items collide with them but no support is
+				// given
 				// In this case, just ignore the collision and let the item fall further
 			}
 			break;
@@ -151,7 +154,8 @@ void BattleItem::update(GameState &state, unsigned int ticks)
 			velocity = {0.0f, 0.0f, 0.0f};
 		}
 		// Collision with map edge
-		if (newPosition.x < 0 || newPosition.y < 0 || newPosition.y >= mapSize.y || newPosition.x >= mapSize.x || newPosition.y >= mapSize.y)
+		if (newPosition.x < 0 || newPosition.y < 0 || newPosition.y >= mapSize.y ||
+		    newPosition.x >= mapSize.x || newPosition.y >= mapSize.y)
 		{
 			collision = true;
 			velocity.x = -velocity.x / 4;
@@ -160,7 +164,7 @@ void BattleItem::update(GameState &state, unsigned int ticks)
 			newPosition = previousPosition;
 		}
 		// Fell below 0???
-		if ( newPosition.z < 0)
+		if (newPosition.z < 0)
 		{
 			LogError("Item fell off the end of the world!?");
 			die(state, false);
@@ -168,7 +172,7 @@ void BattleItem::update(GameState &state, unsigned int ticks)
 		}
 		setPosition(newPosition);
 	}
-	
+
 	if (collision)
 	{
 		findSupport();

--- a/game/state/battle/battleitem.h
+++ b/game/state/battle/battleitem.h
@@ -23,7 +23,7 @@ class BattleItem : public std::enable_shared_from_this<BattleItem>
 
   public:
 	sp<AEquipment> item;
-	
+
 	Vec3<float> getPosition() const { return this->position; }
 
 	Vec3<float> position;
@@ -44,7 +44,7 @@ class BattleItem : public std::enable_shared_from_this<BattleItem>
 	~BattleItem() = default;
 
 	void setPosition(const Vec3<float> &pos);
-	
+
 	Collision checkItemCollision(Vec3<float> previousPosition, Vec3<float> nextPosition);
 
 	bool findSupport(bool emitSound = true, bool forced = false);

--- a/game/state/battle/battleitem.h
+++ b/game/state/battle/battleitem.h
@@ -34,6 +34,8 @@ class BattleItem : public std::enable_shared_from_this<BattleItem>
 
 	bool supported = false;
 
+	int ownerInvulnerableTicks = 0;
+
 	void handleCollision(GameState &state, Collision &c);
 	void die(GameState &state, bool violently);
 	void update(GameState &state, unsigned int ticks);
@@ -42,6 +44,8 @@ class BattleItem : public std::enable_shared_from_this<BattleItem>
 	~BattleItem() = default;
 
 	void setPosition(const Vec3<float> &pos);
+	
+	Collision checkItemCollision(Vec3<float> previousPosition, Vec3<float> nextPosition);
 
 	bool findSupport(bool emitSound = true, bool forced = false);
 

--- a/game/state/battle/battlemap.cpp
+++ b/game/state/battle/battlemap.cpp
@@ -979,7 +979,7 @@ sp<Battle> BattleMap::createBattle(GameState &state, StateRef<Organisation> targ
 
 			b->addUnit(u);
 			u->agent = a;
-			u->agent->unit = { &state, u->id };
+			u->agent->unit = {&state, u->id};
 			u->owner = a->owner;
 			u->squadNumber = -1;
 			u->battle = b;
@@ -1022,7 +1022,8 @@ sp<Battle> BattleMap::createBattle(GameState &state, StateRef<Organisation> targ
 					{
 						if (b->forces[o].squads[s].getNumUnits() >= 3)
 							break;
-						if (u.second->owner != o || u.second->squadNumber != -1 || u.second->retreated)
+						if (u.second->owner != o || u.second->squadNumber != -1 ||
+						    u.second->retreated)
 							continue;
 						u.second->assignToSquad(s);
 						agentCount[o]--;

--- a/game/state/battle/battlemap.cpp
+++ b/game/state/battle/battlemap.cpp
@@ -977,16 +977,17 @@ sp<Battle> BattleMap::createBattle(GameState &state, StateRef<Organisation> targ
 
 			auto u = mksp<BattleUnit>();
 
+			b->addUnit(u);
 			u->agent = a;
+			u->agent->unit = { &state, u->id };
 			u->owner = a->owner;
 			u->squadNumber = -1;
 			u->battle = b;
+			u->updateDisplayedItem();
 			if (!spawnCivilians && a->owner == state.getCivilian())
 			{
 				u->retreated = true;
 			}
-
-			b->units.push_back(u);
 		}
 
 		// Find out number of agents in each org
@@ -998,11 +999,11 @@ sp<Battle> BattleMap::createBattle(GameState &state, StateRef<Organisation> targ
 		}
 		for (auto &u : b->units)
 		{
-			if (u->retreated)
+			if (u.second->retreated)
 			{
 				continue;
 			}
-			agentCount[u->owner]++;
+			agentCount[u.second->owner]++;
 		}
 
 		// Distribute agents into squads
@@ -1021,9 +1022,9 @@ sp<Battle> BattleMap::createBattle(GameState &state, StateRef<Organisation> targ
 					{
 						if (b->forces[o].squads[s].getNumUnits() >= 3)
 							break;
-						if (u->owner != o || u->squadNumber != -1 || u->retreated)
+						if (u.second->owner != o || u.second->squadNumber != -1 || u.second->retreated)
 							continue;
-						u->assignToSquad(s);
+						u.second->assignToSquad(s);
 						agentCount[o]--;
 						if (agentCount[o] == 0)
 							break;
@@ -1039,9 +1040,9 @@ sp<Battle> BattleMap::createBattle(GameState &state, StateRef<Organisation> targ
 				{
 					if (b->forces[o].squads[s].getNumUnits() == 6)
 						break;
-					if (u->owner != o || u->squadNumber != -1)
+					if (u.second->owner != o || u.second->squadNumber != -1)
 						continue;
-					u->assignToSquad(s);
+					u.second->assignToSquad(s);
 					agentCount[o]--;
 					if (agentCount[o] == 0)
 						break;

--- a/game/state/battle/battlemappart.cpp
+++ b/game/state/battle/battlemappart.cpp
@@ -23,16 +23,12 @@ int BattleMapPart::getAnimationFrame()
 	}
 	else
 	{
-		return type->animation_frames.size() == 0
-		           ? -1
-		           : animation_frame_ticks / TICKS_PER_FRAME_MAP_PART;
+		return type->animation_frames.size() == 0 ? -1 : animation_frame_ticks /
+		                                                     TICKS_PER_FRAME_MAP_PART;
 	}
 }
 
-sp<BattleDoor> BattleMapPart::getDoor()
-{
-	return battle->doors[doorID];
-}
+sp<BattleDoor> BattleMapPart::getDoor() { return battle->doors[doorID]; }
 
 void BattleMapPart::handleCollision(GameState &state, Collision &c)
 {

--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -1,7 +1,7 @@
 #define _USE_MATH_DEFINES
-#include "game/state/aequipment.h"
 #include "game/state/battle/battleunit.h"
 #include "framework/framework.h"
+#include "game/state/aequipment.h"
 #include "game/state/battle/battle.h"
 #include "game/state/battle/battleunitanimationpack.h"
 #include "game/state/gamestate.h"
@@ -119,7 +119,8 @@ void BattleUnit::setFocus(StateRef<BattleUnit> unit)
 	auto sft = shared_from_this();
 	if (focusUnit)
 	{
-		auto it = std::find(focusUnit->focusedByUnits.begin(), focusUnit->focusedByUnits.end(), sft);
+		auto it =
+		    std::find(focusUnit->focusedByUnits.begin(), focusUnit->focusedByUnits.end(), sft);
 		if (it != focusUnit->focusedByUnits.end())
 		{
 			focusUnit->focusedByUnits.erase(it);
@@ -155,14 +156,15 @@ void BattleUnit::startAttacking(WeaponStatus status)
 			if (status == WeaponStatus::FiringBothHands)
 			{
 				// Right hand has priority
-				auto rhItem = agent->getFirstItemInSlot(AgentEquipmentLayout::EquipmentSlotType::RightHand);
+				auto rhItem =
+				    agent->getFirstItemInSlot(AgentEquipmentLayout::EquipmentSlotType::RightHand);
 				if (rhItem && rhItem->canFire())
 				{
 					status = WeaponStatus::FiringRightHand;
 				}
 				else
 				{
-					// We don't care what's in the left hand, 
+					// We don't care what's in the left hand,
 					// we will just cancel firing in update() if there's nothing to fire
 					status = WeaponStatus::FiringLeftHand;
 				}
@@ -170,14 +172,16 @@ void BattleUnit::startAttacking(WeaponStatus status)
 			break;
 		case Battle::Mode::RealTime:
 			// Start firing both hands if added one hand to another
-			if ((weaponStatus == WeaponStatus::FiringLeftHand && status == WeaponStatus::FiringRightHand)
-				|| (weaponStatus == WeaponStatus::FiringRightHand && status == WeaponStatus::FiringLeftHand))
+			if ((weaponStatus == WeaponStatus::FiringLeftHand &&
+			     status == WeaponStatus::FiringRightHand) ||
+			    (weaponStatus == WeaponStatus::FiringRightHand &&
+			     status == WeaponStatus::FiringLeftHand))
 			{
 				status = WeaponStatus::FiringBothHands;
 			}
 			break;
 	}
-	
+
 	weaponStatus = status;
 	ticksTillNextTargetCheck = 0;
 }
@@ -191,7 +195,8 @@ void BattleUnit::startAttacking(StateRef<BattleUnit> unit, WeaponStatus status)
 
 void BattleUnit::startAttacking(Vec3<int> tile, WeaponStatus status, bool atGround)
 {
-	startAttacking(status);targetTile = tile;
+	startAttacking(status);
+	targetTile = tile;
 	targetTile = tile;
 	targetingMode = atGround ? TargetingMode::TileGround : TargetingMode::TileCenter;
 }
@@ -203,7 +208,7 @@ void BattleUnit::stopAttacking()
 	ticksTillNextTargetCheck = 0;
 }
 bool BattleUnit::canAfford(int cost) const
-{ 
+{
 	auto b = battle.lock();
 	if (!b)
 	{
@@ -280,7 +285,7 @@ void BattleUnit::dealStunDamage(int damage)
 {
 	// FIXME: Figure out stun damage scale
 	int SCALE = TICKS_PER_SECOND;
-	stunDamageInTicks += damage* SCALE;
+	stunDamageInTicks += damage * SCALE;
 }
 
 bool BattleUnit::isDead() const { return getHealth() == 0 || destroyed; }
@@ -300,15 +305,9 @@ bool BattleUnit::isStatic() const
 	       current_body_state == target_body_state;
 }
 
-bool BattleUnit::isBusy() const
-{
-	return !isStatic() || isAttacking();
-}
+bool BattleUnit::isBusy() const { return !isStatic() || isAttacking(); }
 
-bool BattleUnit::isAttacking() const
-{
-	return weaponStatus != WeaponStatus::NotFiring;
-}
+bool BattleUnit::isAttacking() const { return weaponStatus != WeaponStatus::NotFiring; }
 bool BattleUnit::isThrowing() const
 {
 	bool throwing = false;
@@ -367,8 +366,8 @@ bool BattleUnit::canProne(Vec3<int> pos, Vec2<int> fac) const
 		auto legsTile = tileObject->map.getTile(legsPos);
 		if (legsTile->canStand && std::abs(legsTile->height - bodyTile->height) <= 0.25f &&
 		    legsTile->getPassable(false,
-		                          agent->type->bodyType->height.at(AgentType::BodyState::Prone))
-			&& (legsPos == (Vec3<int>)position || !legsTile->getUnitIfPresent(true, true)))
+		                          agent->type->bodyType->height.at(AgentType::BodyState::Prone)) &&
+		    (legsPos == (Vec3<int>)position || !legsTile->getUnitIfPresent(true, true)))
 		{
 			return true;
 		}
@@ -555,7 +554,7 @@ void BattleUnit::update(GameState &state, unsigned int ticks)
 					}
 					else
 					{
-						// FIXME: Deal damage in a unified way so we don't have to check 
+						// FIXME: Deal damage in a unified way so we don't have to check
 						// for unconscious and dead manually !
 						agent->modified_stats.health -= w.second;
 					}
@@ -599,12 +598,15 @@ void BattleUnit::update(GameState &state, unsigned int ticks)
 		{
 			// If we're given a giveWay request 0, 0 it means we're asked to kneel temporarily
 			if (giveWayRequest.size() == 1 && giveWayRequest.front().x == 0 &&
-			    giveWayRequest.front().y == 0 && canAfford(BattleUnitMission::getBodyStateChangeCost(target_body_state, AgentType::BodyState::Kneeling)))
+			    giveWayRequest.front().y == 0 &&
+			    canAfford(BattleUnitMission::getBodyStateChangeCost(
+			        target_body_state, AgentType::BodyState::Kneeling)))
 			{
 				// Give time for that unit to pass
 				addMission(state, BattleUnitMission::snooze(*this, TICKS_PER_SECOND), false);
 				// Give way
-				addMission(state, BattleUnitMission::changeStance(*this, AgentType::BodyState::Kneeling));
+				addMission(state,
+				           BattleUnitMission::changeStance(*this, AgentType::BodyState::Kneeling));
 			}
 			else
 			{
@@ -622,36 +624,39 @@ void BattleUnit::update(GameState &state, unsigned int ticks)
 						                 position.z + z};
 						auto to = map.getTile(pos);
 						// Check if heading on our level is acceptable
-						bool acceptable = BattleUnitTileHelper{ map, *this }.canEnterTile(from, to) &&
-							BattleUnitTileHelper{ map, *this }.canEnterTile(to, from);
+						bool acceptable = BattleUnitTileHelper{map, *this}.canEnterTile(from, to) &&
+						                  BattleUnitTileHelper{map, *this}.canEnterTile(to, from);
 						// If not, check if we can go down one tile
 						if (!acceptable && pos.z - 1 >= 0)
 						{
 							pos -= Vec3<int>{0, 0, 1};
 							to = map.getTile(pos);
-							acceptable = BattleUnitTileHelper{ map, *this }.canEnterTile(from, to) &&
-								BattleUnitTileHelper{ map, *this }.canEnterTile(to, from);
+							acceptable = BattleUnitTileHelper{map, *this}.canEnterTile(from, to) &&
+							             BattleUnitTileHelper{map, *this}.canEnterTile(to, from);
 						}
 						// If not, check if we can go up one tile
-						if (!acceptable && pos.z +2 < map.size.z)
+						if (!acceptable && pos.z + 2 < map.size.z)
 						{
 							pos += Vec3<int>{0, 0, 2};
 							to = map.getTile(pos);
-							acceptable = BattleUnitTileHelper{ map, *this }.canEnterTile(from, to) &&
-								BattleUnitTileHelper{ map, *this }.canEnterTile(to, from);
+							acceptable = BattleUnitTileHelper{map, *this}.canEnterTile(from, to) &&
+							             BattleUnitTileHelper{map, *this}.canEnterTile(to, from);
 						}
 						if (acceptable)
 						{
 							// 05: Turn to previous facing
 							addMission(state, BattleUnitMission::turn(*this, facing), false);
 							// 04: Return to our position after we're done
-							addMission(state, BattleUnitMission::gotoLocation(*this, position, 0, false), false);
+							addMission(state,
+							           BattleUnitMission::gotoLocation(*this, position, 0, false),
+							           false);
 							// 03: Give time for that unit to pass
 							addMission(state, BattleUnitMission::snooze(*this, 60), false);
 							// 02: Turn to previous facing
 							addMission(state, BattleUnitMission::turn(*this, facing), false);
 							// 01: Give way (move 1 tile away)
-							addMission(state, BattleUnitMission::gotoLocation(*this, pos, 0, false));
+							addMission(state,
+							           BattleUnitMission::gotoLocation(*this, pos, 0, false));
 						}
 						if (!missions.empty())
 						{
@@ -665,24 +670,28 @@ void BattleUnit::update(GameState &state, unsigned int ticks)
 				}
 			}
 			giveWayRequest.clear();
-		}  
+		}
 		else // if not giving way
 		{
 			setMovementState(AgentType::MovementState::None);
 			// Kneel if not kneeling and should kneel
 			if (kneeling_mode == KneelingMode::Kneeling &&
-			    current_body_state != AgentType::BodyState::Kneeling && canKneel()
-				&& canAfford(BattleUnitMission::getBodyStateChangeCost(target_body_state, AgentType::BodyState::Kneeling)))
+			    current_body_state != AgentType::BodyState::Kneeling && canKneel() &&
+			    canAfford(BattleUnitMission::getBodyStateChangeCost(
+			        target_body_state, AgentType::BodyState::Kneeling)))
 			{
-				addMission(state, BattleUnitMission::changeStance(*this, AgentType::BodyState::Kneeling));
+				addMission(state,
+				           BattleUnitMission::changeStance(*this, AgentType::BodyState::Kneeling));
 			}
 			// Go prone if not prone and should stay prone
 			else if (movement_mode == BattleUnit::MovementMode::Prone &&
 			         current_body_state != AgentType::BodyState::Prone &&
-			         kneeling_mode != KneelingMode::Kneeling && canProne(position, facing)
-				&& canAfford(BattleUnitMission::getBodyStateChangeCost(target_body_state, AgentType::BodyState::Prone)))
+			         kneeling_mode != KneelingMode::Kneeling && canProne(position, facing) &&
+			         canAfford(BattleUnitMission::getBodyStateChangeCost(
+			             target_body_state, AgentType::BodyState::Prone)))
 			{
-				addMission(state, BattleUnitMission::changeStance(*this, AgentType::BodyState::Prone));
+				addMission(state,
+				           BattleUnitMission::changeStance(*this, AgentType::BodyState::Prone));
 			}
 			// Stand up if not standing up and should stand up
 			else if ((movement_mode == BattleUnit::MovementMode::Walking ||
@@ -693,26 +702,32 @@ void BattleUnit::update(GameState &state, unsigned int ticks)
 			{
 				if (agent->isBodyStateAllowed(AgentType::BodyState::Standing))
 				{
-					if (canAfford(BattleUnitMission::getBodyStateChangeCost(target_body_state, AgentType::BodyState::Standing)))
+					if (canAfford(BattleUnitMission::getBodyStateChangeCost(
+					        target_body_state, AgentType::BodyState::Standing)))
 					{
-						addMission(state, BattleUnitMission::changeStance(*this, AgentType::BodyState::Standing));
+						addMission(state, BattleUnitMission::changeStance(
+						                      *this, AgentType::BodyState::Standing));
 					}
 				}
 				else
 				{
-					if (canAfford(BattleUnitMission::getBodyStateChangeCost(target_body_state, AgentType::BodyState::Flying)))
+					if (canAfford(BattleUnitMission::getBodyStateChangeCost(
+					        target_body_state, AgentType::BodyState::Flying)))
 					{
-						addMission(state, BattleUnitMission::changeStance(*this, AgentType::BodyState::Flying));
+						addMission(state, BattleUnitMission::changeStance(
+						                      *this, AgentType::BodyState::Flying));
 					}
 				}
 			}
 			// Stop flying if we can stand
 			else if (current_body_state == AgentType::BodyState::Flying &&
 			         tileObject->getOwningTile()->getCanStand(isLarge()) &&
-			         agent->isBodyStateAllowed(AgentType::BodyState::Standing)
-				&& canAfford(BattleUnitMission::getBodyStateChangeCost(target_body_state, AgentType::BodyState::Standing)))
+			         agent->isBodyStateAllowed(AgentType::BodyState::Standing) &&
+			         canAfford(BattleUnitMission::getBodyStateChangeCost(
+			             target_body_state, AgentType::BodyState::Standing)))
 			{
-				addMission(state, BattleUnitMission::changeStance(*this, AgentType::BodyState::Standing));
+				addMission(state,
+				           BattleUnitMission::changeStance(*this, AgentType::BodyState::Standing));
 			}
 			// Stop being prone if legs are no longer supported and we haven't taken a mission yet
 			if (current_body_state == AgentType::BodyState::Prone && missions.empty())
@@ -726,9 +741,11 @@ void BattleUnit::update(GameState &state, unsigned int ticks)
 						break;
 					}
 				}
-				if (!hasSupport && canAfford(BattleUnitMission::getBodyStateChangeCost(target_body_state, AgentType::BodyState::Kneeling)))
+				if (!hasSupport && canAfford(BattleUnitMission::getBodyStateChangeCost(
+				                       target_body_state, AgentType::BodyState::Kneeling)))
 				{
-					addMission(state, BattleUnitMission::changeStance(*this, AgentType::BodyState::Kneeling));
+					addMission(state, BattleUnitMission::changeStance(
+					                      *this, AgentType::BodyState::Kneeling));
 				}
 			}
 		}
@@ -872,7 +889,7 @@ void BattleUnit::update(GameState &state, unsigned int ticks)
 					}
 				}
 			}
-			
+
 			// Try moving
 			if (moveTicksRemaining > 0)
 			{
@@ -880,7 +897,8 @@ void BattleUnit::update(GameState &state, unsigned int ticks)
 				if (falling)
 				{
 					// Falling consumes remaining move ticks
-					auto fallTicksRemaining = moveTicksRemaining / (agent->modified_stats.getActualSpeedValue() * 2);
+					auto fallTicksRemaining =
+					    moveTicksRemaining / (agent->modified_stats.getActualSpeedValue() * 2);
 					moveTicksRemaining = 0;
 
 					// Process falling
@@ -888,11 +906,13 @@ void BattleUnit::update(GameState &state, unsigned int ticks)
 					while (fallTicksRemaining-- > 0)
 					{
 						fallingSpeed += FALLING_ACCELERATION_UNIT;
-						newPosition -= Vec3<float>{0.0f, 0.0f, (fallingSpeed / TICK_SCALE)} / VELOCITY_SCALE_BATTLE;
+						newPosition -= Vec3<float>{0.0f, 0.0f, (fallingSpeed / TICK_SCALE)} /
+						               VELOCITY_SCALE_BATTLE;
 					}
 					// Fell into a unit
-					if (isConscious() && map.getTile(newPosition)->getUnitIfPresent(true, true, false, tileObject))
-					{	
+					if (isConscious() &&
+					    map.getTile(newPosition)->getUnitIfPresent(true, true, false, tileObject))
+					{
 						// FIXME: Proper stun damage (ensure it is!)
 						stunDamageInTicks = 0;
 						dealStunDamage(agent->current_stats.health * 3 / 2);
@@ -937,8 +957,8 @@ void BattleUnit::update(GameState &state, unsigned int ticks)
 					}
 
 					Vec3<float> vectorToGoal = goalPosition - getPosition();
-					int distanceToGoal = (int)ceilf(glm::length(vectorToGoal * VELOCITY_SCALE_BATTLE *
-					                                       (float)TICKS_PER_UNIT_TRAVELLED));
+					int distanceToGoal = (int)ceilf(glm::length(
+					    vectorToGoal * VELOCITY_SCALE_BATTLE * (float)TICKS_PER_UNIT_TRAVELLED));
 					int moveTicksConsumeRate =
 					    current_movement_state == AgentType::MovementState::Running ? 1 : 2;
 
@@ -962,22 +982,22 @@ void BattleUnit::update(GameState &state, unsigned int ticks)
 						if (flyingSpeedModifier != 100)
 						{
 							flyingSpeedModifier =
-								std::min(100, flyingSpeedModifier +
-									moveTicksRemaining / moveTicksConsumeRate /
-									FLYING_ACCELERATION_DIVISOR);
+							    std::min(100, flyingSpeedModifier +
+							                      moveTicksRemaining / moveTicksConsumeRate /
+							                          FLYING_ACCELERATION_DIVISOR);
 						}
 						movementTicksAccumulated = moveTicksRemaining / moveTicksConsumeRate;
 						auto dir = glm::normalize(vectorToGoal);
 						Vec3<float> newPosition =
-							(float)(moveTicksRemaining / moveTicksConsumeRate) *
-							(float)(speedModifier / 100) * dir;
+						    (float)(moveTicksRemaining / moveTicksConsumeRate) *
+						    (float)(speedModifier / 100) * dir;
 						newPosition /= VELOCITY_SCALE_BATTLE;
 						newPosition /= (float)TICKS_PER_UNIT_TRAVELLED;
 						newPosition += getPosition();
 						setPosition(newPosition);
 						moveTicksRemaining = moveTicksRemaining % moveTicksConsumeRate;
 						atGoal = false;
-					} 
+					}
 					else
 					{
 						if (distanceToGoal > 0)
@@ -1007,7 +1027,7 @@ void BattleUnit::update(GameState &state, unsigned int ticks)
 							atGoal = false;
 						}
 					}
-					
+
 					// Scale ticks so that animations look proper on isometric sceen
 					// facing down or up on screen
 					if (facing.x == facing.y)
@@ -1077,7 +1097,7 @@ void BattleUnit::update(GameState &state, unsigned int ticks)
 					}
 				}
 			}
-		
+
 			// Try turning
 			if (turnTicksRemaining > 0)
 			{
@@ -1115,57 +1135,58 @@ void BattleUnit::update(GameState &state, unsigned int ticks)
 
 	// Firing
 
-	static const Vec3<float> offsetTile = { 0.5f, 0.5f, 0.0f };
-	static const Vec3<float> offsetTileGround = { 0.5f, 0.5f, 10.0f/40.0f };
+	static const Vec3<float> offsetTile = {0.5f, 0.5f, 0.0f};
+	static const Vec3<float> offsetTileGround = {0.5f, 0.5f, 10.0f / 40.0f};
 	Vec3<float> targetPosition;
 	switch (targetingMode)
 	{
-	case TargetingMode::Unit:
-		targetPosition = targetUnit->tileObject->getVoxelCentrePosition();
-		break;
-	case TargetingMode::TileCenter:
-	{
-		float unitZ = (position + Vec3<float>{0.0f, 0.0f, (float)getCurrentHeight() / 40.0f}).z;
-		unitZ -= (int)unitZ;
-		targetPosition = (Vec3<float>)targetTile + offsetTile + Vec3<float>{0.0f, 0.0f, unitZ};
-		break;
-	}
-	case TargetingMode::TileGround:
-		targetPosition = (Vec3<float>)targetTile + offsetTileGround;
-		break;
+		case TargetingMode::Unit:
+			targetPosition = targetUnit->tileObject->getVoxelCentrePosition();
+			break;
+		case TargetingMode::TileCenter:
+		{
+			float unitZ = (position + Vec3<float>{0.0f, 0.0f, (float)getCurrentHeight() / 40.0f}).z;
+			unitZ -= (int)unitZ;
+			targetPosition = (Vec3<float>)targetTile + offsetTile + Vec3<float>{0.0f, 0.0f, unitZ};
+			break;
+		}
+		case TargetingMode::TileGround:
+			targetPosition = (Vec3<float>)targetTile + offsetTileGround;
+			break;
 	}
 
 	// For simplicity, prepare weapons we can use
 	// We can use a weapon if we're set to fire this hand, and it's a weapon that can be fired
 
-	auto weaponRight = agent->getFirstItemInSlot(AgentEquipmentLayout::EquipmentSlotType::RightHand);
+	auto weaponRight =
+	    agent->getFirstItemInSlot(AgentEquipmentLayout::EquipmentSlotType::RightHand);
 	auto weaponLeft = agent->getFirstItemInSlot(AgentEquipmentLayout::EquipmentSlotType::LeftHand);
 	switch (weaponStatus)
 	{
-	case WeaponStatus::FiringBothHands:
-		if (weaponRight && !weaponRight->canFire())
-		{
-			weaponRight = nullptr;
-		}
-		if (weaponLeft && !weaponLeft->canFire())
-		{
+		case WeaponStatus::FiringBothHands:
+			if (weaponRight && !weaponRight->canFire())
+			{
+				weaponRight = nullptr;
+			}
+			if (weaponLeft && !weaponLeft->canFire())
+			{
+				weaponLeft = nullptr;
+			}
+			break;
+		case WeaponStatus::FiringRightHand:
+			if (weaponRight && !weaponRight->canFire())
+			{
+				weaponRight = nullptr;
+			}
 			weaponLeft = nullptr;
-		}
-		break;
-	case WeaponStatus::FiringRightHand:
-		if (weaponRight && !weaponRight->canFire())
-		{
+			break;
+		case WeaponStatus::FiringLeftHand:
+			if (weaponLeft && !weaponLeft->canFire())
+			{
+				weaponLeft = nullptr;
+			}
 			weaponRight = nullptr;
-		}
-		weaponLeft = nullptr;
-		break;
-	case WeaponStatus::FiringLeftHand:
-		if (weaponLeft && !weaponLeft->canFire())
-		{
-			weaponLeft = nullptr;
-		}
-		weaponRight = nullptr;
-		break;
+			break;
 	}
 
 	// Firing - check if we should stop firing
@@ -1188,8 +1209,9 @@ void BattleUnit::update(GameState &state, unsigned int ticks)
 
 		// We cannot fire if we have no weapon capable of firing
 		canFire = canFire && (weaponLeft || weaponRight);
-		
-		// We cannot fire if it's time to check target unit and it's not in LOS anymore or not conscious
+
+		// We cannot fire if it's time to check target unit and it's not in LOS anymore or not
+		// conscious
 		// Also, at this point we will turn to target tile if targeting tile
 		if (canFire)
 		{
@@ -1202,7 +1224,7 @@ void BattleUnit::update(GameState &state, unsigned int ticks)
 				{
 					canFire = canFire && targetUnit->isConscious();
 					LogWarning("Implement checking LOS to targetUnit");
-					canFire = canFire && true;// Here we check if target is visible
+					canFire = canFire && true; // Here we check if target is visible
 					if (canFire)
 					{
 						targetTile = targetUnit->position;
@@ -1211,7 +1233,9 @@ void BattleUnit::update(GameState &state, unsigned int ticks)
 				// Check if we are in range
 				if (canFire)
 				{
-					float distanceToTarget = glm::length(position + Vec3<float>{0.0f, 0.0f, (float)getCurrentHeight() / 40.0f} -targetPosition);
+					float distanceToTarget = glm::length(
+					    position + Vec3<float>{0.0f, 0.0f, (float)getCurrentHeight() / 40.0f} -
+					    targetPosition);
 					if (weaponRight && !weaponRight->canFire(distanceToTarget))
 					{
 						weaponRight = nullptr;
@@ -1241,7 +1265,7 @@ void BattleUnit::update(GameState &state, unsigned int ticks)
 			stopAttacking();
 		}
 	}
-	 
+
 	// Firing - process unit that is firing
 	if (isAttacking())
 	{
@@ -1257,9 +1281,8 @@ void BattleUnit::update(GameState &state, unsigned int ticks)
 
 		// Is a gun ready to fire?
 		bool weaponFired = false;
-		if (firing_animation_ticks_remaining == 0 
-			&& hand_animation_ticks_remaining == 0 
-			&& current_hand_state == AgentType::HandState::Aiming)
+		if (firing_animation_ticks_remaining == 0 && hand_animation_ticks_remaining == 0 &&
+		    current_hand_state == AgentType::HandState::Aiming)
 		{
 			sp<AEquipment> firingWeapon = nullptr;
 			if (weaponRight && weaponRight->readyToFire)
@@ -1276,9 +1299,10 @@ void BattleUnit::update(GameState &state, unsigned int ticks)
 			if (firingWeapon)
 			{
 				auto targetVector = targetPosition - position;
-				targetVector = { targetVector.x, targetVector.y, 0.0f };
+				targetVector = {targetVector.x, targetVector.y, 0.0f};
 				// Target must be within frontal arc
-				if (glm::angle(glm::normalize(targetVector), glm::normalize(Vec3<float>{facing.x, facing.y, 0})) >= M_PI / 2)
+				if (glm::angle(glm::normalize(targetVector),
+				               glm::normalize(Vec3<float>{facing.x, facing.y, 0})) >= M_PI / 2)
 				{
 					firingWeapon = nullptr;
 				}
@@ -1300,49 +1324,48 @@ void BattleUnit::update(GameState &state, unsigned int ticks)
 		{
 			switch (weaponStatus)
 			{
-			case WeaponStatus::FiringBothHands:
-				if (!weaponRight)
-				{
+				case WeaponStatus::FiringBothHands:
+					if (!weaponRight)
+					{
+						if (!weaponLeft)
+						{
+							stopAttacking();
+						}
+						else
+						{
+							weaponStatus = WeaponStatus::FiringLeftHand;
+						}
+					}
+					else if (!weaponLeft)
+					{
+						weaponStatus = WeaponStatus::FiringRightHand;
+					}
+					break;
+				case WeaponStatus::FiringLeftHand:
 					if (!weaponLeft)
 					{
 						stopAttacking();
 					}
-					else
+					break;
+				case WeaponStatus::FiringRightHand:
+					if (!weaponRight)
 					{
-						weaponStatus = WeaponStatus::FiringLeftHand;
+						stopAttacking();
 					}
-				}
-				else if (!weaponLeft)
-				{
-					weaponStatus = WeaponStatus::FiringRightHand;
-				}
-				break;
-			case WeaponStatus::FiringLeftHand:
-				if (!weaponLeft)
-				{
-					stopAttacking();
-				}
-				break;
-			case WeaponStatus::FiringRightHand:
-				if (!weaponRight)
-				{
-					stopAttacking();
-				}
-				break;
+					break;
 			}
 		}
 
 		// Should we start aiming?
-		if (firing_animation_ticks_remaining == 0
-			&& hand_animation_ticks_remaining == 0
-			&& current_hand_state != AgentType::HandState::Aiming
-			&& current_movement_state!= AgentType::MovementState::Running
-			&& current_movement_state != AgentType::MovementState::Strafing)
+		if (firing_animation_ticks_remaining == 0 && hand_animation_ticks_remaining == 0 &&
+		    current_hand_state != AgentType::HandState::Aiming &&
+		    current_movement_state != AgentType::MovementState::Running &&
+		    current_movement_state != AgentType::MovementState::Strafing)
 		{
 			beginHandStateChange(AgentType::HandState::Aiming);
 		}
 
-	}// end if Firing - process firing
+	} // end if Firing - process firing
 
 	// Not Firing (or may have just stopped firing)
 	if (!isAttacking())
@@ -1352,13 +1375,12 @@ void BattleUnit::update(GameState &state, unsigned int ticks)
 		{
 			aiming_ticks_remaining -= ticks;
 		}
-		else if (firing_animation_ticks_remaining == 0
-			&& hand_animation_ticks_remaining == 0
-			&& current_hand_state == AgentType::HandState::Aiming)
+		else if (firing_animation_ticks_remaining == 0 && hand_animation_ticks_remaining == 0 &&
+		         current_hand_state == AgentType::HandState::Aiming)
 		{
 			beginHandStateChange(AgentType::HandState::AtEase);
 		}
-	}// end if not Firing
+	} // end if not Firing
 
 	// FIXME: Soldier "thinking" (auto-attacking, auto-turning)
 }
@@ -1383,19 +1405,19 @@ void BattleUnit::updateDisplayedItem()
 	if (!foundThrownItem)
 	{
 		// If we're firing - try to keep last displayed item same, even if not dominant
-		displayedItem = agent->getDominantItemInHands(firing_animation_ticks_remaining > 0 ? lastDisplayedItem : nullptr);
+		displayedItem = agent->getDominantItemInHands(
+		    firing_animation_ticks_remaining > 0 ? lastDisplayedItem : nullptr);
 	}
 	// If displayed item changed or we are throwing - bring hands into "AtEase" state immediately
 	if (foundThrownItem || displayedItem != lastDisplayedItem)
 	{
-		if (hand_animation_ticks_remaining > 0 || current_hand_state != AgentType::HandState::AtEase)
+		if (hand_animation_ticks_remaining > 0 ||
+		    current_hand_state != AgentType::HandState::AtEase)
 		{
 			setHandState(AgentType::HandState::AtEase);
 		}
 	}
 }
-
-
 
 void BattleUnit::destroy(GameState &)
 {
@@ -1413,8 +1435,8 @@ void BattleUnit::tryToRiseUp(GameState &state)
 
 	// Find state we can rise into (with animation)
 	auto targetState = AgentType::BodyState::Standing;
-	while (targetState != AgentType::BodyState::Downed
-		&& agent->getAnimationPack()->getFrameCountBody(displayedItem, current_body_state,
+	while (targetState != AgentType::BodyState::Downed &&
+	       agent->getAnimationPack()->getFrameCountBody(displayedItem, current_body_state,
 	                                                    targetState, current_hand_state,
 	                                                    current_movement_state, facing) == 0)
 	{
@@ -1485,8 +1507,8 @@ void BattleUnit::dropDown(GameState &state)
 	setBodyState(target_body_state);
 	// Check if we can drop from current state
 	while (agent->getAnimationPack()->getFrameCountBody(
-			displayedItem, current_body_state, AgentType::BodyState::Downed,
-	           current_hand_state, current_movement_state, facing) == 0)
+	           displayedItem, current_body_state, AgentType::BodyState::Downed, current_hand_state,
+	           current_movement_state, facing) == 0)
 	{
 		switch (current_body_state)
 		{
@@ -1550,16 +1572,16 @@ void BattleUnit::beginBodyStateChange(AgentType::BodyState state)
 		setHandState(target_hand_state);
 
 	// Find which animation is possible
-	int frameCount = agent->getAnimationPack()->getFrameCountBody(
-		displayedItem, current_body_state, state, current_hand_state,
-		current_movement_state, facing);
+	int frameCount = agent->getAnimationPack()->getFrameCountBody(displayedItem, current_body_state,
+	                                                              state, current_hand_state,
+	                                                              current_movement_state, facing);
 	// No such animation
 	// Try stopping movement
 	if (frameCount == 0 && current_movement_state != AgentType::MovementState::None)
 	{
 		frameCount = agent->getAnimationPack()->getFrameCountBody(
-			displayedItem, current_body_state, state, current_hand_state,
-			AgentType::MovementState::None, facing);
+		    displayedItem, current_body_state, state, current_hand_state,
+		    AgentType::MovementState::None, facing);
 		if (frameCount != 0)
 		{
 			setMovementState(AgentType::MovementState::None);
@@ -1569,8 +1591,8 @@ void BattleUnit::beginBodyStateChange(AgentType::BodyState state)
 	if (frameCount == 0 && current_hand_state != AgentType::HandState::AtEase)
 	{
 		frameCount = agent->getAnimationPack()->getFrameCountBody(
-			displayedItem, current_body_state, state, AgentType::HandState::AtEase,
-			current_movement_state, facing);
+		    displayedItem, current_body_state, state, AgentType::HandState::AtEase,
+		    current_movement_state, facing);
 		if (frameCount != 0)
 		{
 			setHandState(AgentType::HandState::AtEase);
@@ -1608,7 +1630,9 @@ void BattleUnit::setBodyState(AgentType::BodyState state)
 
 void BattleUnit::beginHandStateChange(AgentType::HandState state)
 {
-	int frameCount = agent->getAnimationPack()->getFrameCountHands(displayedItem, current_body_state, current_hand_state, state, current_movement_state, facing);
+	int frameCount = agent->getAnimationPack()->getFrameCountHands(
+	    displayedItem, current_body_state, current_hand_state, state, current_movement_state,
+	    facing);
 	int ticks = frameCount * TICKS_PER_FRAME_UNIT;
 
 	if (ticks > 0 && current_hand_state != state)
@@ -1623,13 +1647,17 @@ void BattleUnit::beginHandStateChange(AgentType::HandState state)
 	aiming_ticks_remaining = 0;
 }
 
-
 void BattleUnit::setHandState(AgentType::HandState state)
 {
 	current_hand_state = state;
 	target_hand_state = state;
 	hand_animation_ticks_remaining = 0;
-	firing_animation_ticks_remaining = state != AgentType::HandState::Firing ? 0 : agent->getAnimationPack()->getFrameCountFiring(displayedItem, current_body_state, current_movement_state, facing) * TICKS_PER_FRAME_UNIT;
+	firing_animation_ticks_remaining =
+	    state != AgentType::HandState::Firing
+	        ? 0
+	        : agent->getAnimationPack()->getFrameCountFiring(displayedItem, current_body_state,
+	                                                         current_movement_state, facing) *
+	              TICKS_PER_FRAME_UNIT;
 	aiming_ticks_remaining = state == AgentType::HandState::Aiming ? TICKS_PER_SECOND / 3 : 0;
 }
 
@@ -1644,24 +1672,25 @@ void BattleUnit::setMovementState(AgentType::MovementState state)
 	current_movement_state = state;
 	switch (state)
 	{
-	case AgentType::MovementState::None:
-		movement_ticks_passed = 0;
-		movement_sounds_played = 0;
-		ticksTillNextTargetCheck = 0;
-		break;
-	case AgentType::MovementState::Running:
-	case AgentType::MovementState::Strafing:
-		if (current_hand_state != AgentType::HandState::AtEase || target_hand_state != AgentType::HandState::AtEase)
-		{
-			setHandState(AgentType::HandState::AtEase);
-		}
-		if (isAttacking())
-		{
-			stopAttacking();
-		}
-		break;
-	default:
-		break;
+		case AgentType::MovementState::None:
+			movement_ticks_passed = 0;
+			movement_sounds_played = 0;
+			ticksTillNextTargetCheck = 0;
+			break;
+		case AgentType::MovementState::Running:
+		case AgentType::MovementState::Strafing:
+			if (current_hand_state != AgentType::HandState::AtEase ||
+			    target_hand_state != AgentType::HandState::AtEase)
+			{
+				setHandState(AgentType::HandState::AtEase);
+			}
+			if (isAttacking())
+			{
+				stopAttacking();
+			}
+			break;
+		default:
+			break;
 	}
 }
 
@@ -1691,7 +1720,8 @@ float BattleUnit::getMaxThrowDistance(int weight, int heightDifference)
 		return max;
 	}
 	int mod = heightDifference > 0 ? heightDifference : heightDifference * 2;
-	return std::max(0.0f, std::min(max, (float)agent->modified_stats.strength / ((float)weight - 1) - 2 + mod));
+	return std::max(
+	    0.0f, std::min(max, (float)agent->modified_stats.strength / ((float)weight - 1) - 2 + mod));
 }
 
 bool BattleUnit::shouldPlaySoundNow()
@@ -1813,27 +1843,43 @@ bool BattleUnit::addMission(GameState &state, BattleUnitMission *mission, bool s
 			if (missions.empty())
 			{
 				missions.emplace_front(mission);
-				if (start) { mission->start(state, *this); }
+				if (start)
+				{
+					mission->start(state, *this);
+				}
 			}
 			else if (missions.front()->type == BattleUnitMission::MissionType::AcquireTU)
 			{
 				missions.clear();
 				missions.emplace_front(mission);
-				if (start) { mission->start(state, *this); }
+				if (start)
+				{
+					mission->start(state, *this);
+				}
 			}
 			else
 			{
 				auto it = missions.begin();
-				while (it != missions.end() && (*it)->type != BattleUnitMission::MissionType::ThrowItem && ++it != missions.end()) {}
+				while (it != missions.end() &&
+				       (*it)->type != BattleUnitMission::MissionType::ThrowItem &&
+				       ++it != missions.end())
+				{
+				}
 				if (it == missions.end())
 				{
 					missions.emplace_front(mission);
-					if (start) { mission->start(state, *this); }
+					if (start)
+					{
+						mission->start(state, *this);
+					}
 				}
 				else
 				{
 					missions.emplace(++it, mission);
-					if (start) { mission->start(state, *this); }
+					if (start)
+					{
+						mission->start(state, *this);
+					}
 				}
 			}
 			break;
@@ -1847,20 +1893,20 @@ bool BattleUnit::addMission(GameState &state, BattleUnitMission *mission, bool s
 				switch (missions.front()->type)
 				{
 					// Missions that prevent going to goal
-				case BattleUnitMission::MissionType::Fall:
-				case BattleUnitMission::MissionType::Snooze:
-				case BattleUnitMission::MissionType::ThrowItem:
-				case BattleUnitMission::MissionType::ChangeBodyState:
-				case BattleUnitMission::MissionType::Turn:
-				case BattleUnitMission::MissionType::ReachGoal:
-					shouldMoveToGoal = false;
-					break;
+					case BattleUnitMission::MissionType::Fall:
+					case BattleUnitMission::MissionType::Snooze:
+					case BattleUnitMission::MissionType::ThrowItem:
+					case BattleUnitMission::MissionType::ChangeBodyState:
+					case BattleUnitMission::MissionType::Turn:
+					case BattleUnitMission::MissionType::ReachGoal:
+						shouldMoveToGoal = false;
+						break;
 					// Missions that can be overwritten
-				case BattleUnitMission::MissionType::AcquireTU:
-				case BattleUnitMission::MissionType::GotoLocation:
-				case BattleUnitMission::MissionType::RestartNextMission:
-					shouldMoveToGoal = true;
-					break;
+					case BattleUnitMission::MissionType::AcquireTU:
+					case BattleUnitMission::MissionType::GotoLocation:
+					case BattleUnitMission::MissionType::RestartNextMission:
+						shouldMoveToGoal = true;
+						break;
 				}
 			}
 			if (!shouldMoveToGoal)
@@ -1868,24 +1914,34 @@ bool BattleUnit::addMission(GameState &state, BattleUnitMission *mission, bool s
 				return false;
 			}
 			missions.emplace_front(mission);
-			if (start) { mission->start(state, *this); }
+			if (start)
+			{
+				mission->start(state, *this);
+			}
 			break;
 		}
-		// Turn that requires goal can only be added 
+		// Turn that requires goal can only be added
 		// if it's not added in front of "reachgoal" mission
 		case BattleUnitMission::MissionType::Turn:
 		{
 			if (mission->requireGoal)
 			{
 				auto it = missions.begin();
-				while (it != missions.end() && (*it)->type != BattleUnitMission::MissionType::ReachGoal && ++it != missions.end()) {}
+				while (it != missions.end() &&
+				       (*it)->type != BattleUnitMission::MissionType::ReachGoal &&
+				       ++it != missions.end())
+				{
+				}
 				if (it != missions.end())
 				{
 					return false;
 				}
 			}
 			missions.emplace_front(mission);
-			if (start) { mission->start(state, *this); }
+			if (start)
+			{
+				mission->start(state, *this);
+			}
 			break;
 		}
 		// Snooze, change body state, acquire TU, restart and teleport can be added at any time
@@ -1895,14 +1951,20 @@ bool BattleUnit::addMission(GameState &state, BattleUnitMission *mission, bool s
 		case BattleUnitMission::MissionType::RestartNextMission:
 		case BattleUnitMission::MissionType::Teleport:
 			missions.emplace_front(mission);
-			if (start) { mission->start(state, *this); }
+			if (start)
+			{
+				mission->start(state, *this);
+			}
 			break;
-			// FIXME: Implement this
+		// FIXME: Implement this
 		case BattleUnitMission::MissionType::ThrowItem:
 		case BattleUnitMission::MissionType::GotoLocation:
 			LogWarning("Adding Throw/GoTo : Ensure implemented correctly!");
 			missions.emplace_front(mission);
-			if (start) { mission->start(state, *this); }
+			if (start)
+			{
+				mission->start(state, *this);
+			}
 			break;
 		default:
 			LogError("Unimplemented");

--- a/game/state/battle/battleunit.h
+++ b/game/state/battle/battleunit.h
@@ -78,7 +78,7 @@ class BattleUnit : public StateObject<BattleUnit>, public std::enable_shared_fro
 		TileCenter,
 		TileGround
 	};
-	
+
 	UString id;
 
 	StateRef<Agent> agent;
@@ -91,12 +91,12 @@ class BattleUnit : public StateObject<BattleUnit>, public std::enable_shared_fro
 	void moveToSquadPosition(int squadPosition);
 
 	// Weapon state and firing
-	
+
 	WeaponStatus weaponStatus = WeaponStatus::NotFiring;
 	TargetingMode targetingMode = TargetingMode::NoTarget;
 	// Tile we're targeting right now (or tile with unit we're targeting)
 	Vec3<int> targetTile;
-	// Unit we're targeting right now 
+	// Unit we're targeting right now
 	StateRef<BattleUnit> targetUnit;
 	// Unit we're ordered to focus on (in real time)
 	StateRef<BattleUnit> focusUnit;
@@ -105,8 +105,10 @@ class BattleUnit : public StateObject<BattleUnit>, public std::enable_shared_fro
 	int ticksTillNextTargetCheck = 0;
 
 	void setFocus(StateRef<BattleUnit> unit);
-	void startAttacking(StateRef<BattleUnit> unit, WeaponStatus status = WeaponStatus::FiringBothHands);
-	void startAttacking(Vec3<int> tile, WeaponStatus status = WeaponStatus::FiringBothHands, bool atGround = false);
+	void startAttacking(StateRef<BattleUnit> unit,
+	                    WeaponStatus status = WeaponStatus::FiringBothHands);
+	void startAttacking(Vec3<int> tile, WeaponStatus status = WeaponStatus::FiringBothHands,
+	                    bool atGround = false);
 	void stopAttacking();
 
 	// Stats
@@ -147,7 +149,7 @@ class BattleUnit : public StateObject<BattleUnit>, public std::enable_shared_fro
 	AgentType::BodyState target_body_state = AgentType::BodyState::Standing;
 	void setBodyState(AgentType::BodyState state);
 	void beginBodyStateChange(AgentType::BodyState state);
-	
+
 	// Time, in game ticks, until hands animation is finished
 	int hand_animation_ticks_remaining = 0;
 	// Time, in game ticks, until unit will lower it's weapon
@@ -157,10 +159,10 @@ class BattleUnit : public StateObject<BattleUnit>, public std::enable_shared_fro
 	// Get hand animation frame to draw
 	int getHandAnimationFrame() const
 	{
-		return ((firing_animation_ticks_remaining > 0 
-			? firing_animation_ticks_remaining 
-			: hand_animation_ticks_remaining) 
-			+ TICKS_PER_FRAME_UNIT - 1) / TICKS_PER_FRAME_UNIT;
+		return ((firing_animation_ticks_remaining > 0 ? firing_animation_ticks_remaining
+		                                              : hand_animation_ticks_remaining) +
+		        TICKS_PER_FRAME_UNIT - 1) /
+		       TICKS_PER_FRAME_UNIT;
 	}
 	AgentType::HandState current_hand_state = AgentType::HandState::AtEase;
 	AgentType::HandState target_hand_state = AgentType::HandState::AtEase;
@@ -173,14 +175,14 @@ class BattleUnit : public StateObject<BattleUnit>, public std::enable_shared_fro
 	{
 		return std::max(0, movement_ticks_passed / TICKS_PER_UNIT_TRAVELLED);
 	}
-	
+
 	// Movement sounds
 	int movement_sounds_played = 0;
 	bool shouldPlaySoundNow();
 	int getWalkSoundIndex();
 	AgentType::MovementState current_movement_state = AgentType::MovementState::None;
 	void setMovementState(AgentType::MovementState state);
-	
+
 	// Time, in game ticks, until unit can turn by 1/8th of a circle
 	int turning_animation_ticks_remaining = 0;
 	void beginTurning(Vec2<int> newFacing);
@@ -207,14 +209,14 @@ class BattleUnit : public StateObject<BattleUnit>, public std::enable_shared_fro
 
 	// Successfully retreated from combat
 	bool retreated = false;
-	
+
 	// Died and corpse was destroyed in an explosion
 	bool destroyed = false;
-	
+
 	// Freefalling
 	bool falling = false;
 	float fallingSpeed = 0.0f;
-	
+
 	// If unit is asked to give way, this list will be filled with facings
 	// in order of priority that should be tried by it
 	std::list<Vec2<int>> giveWayRequest;
@@ -254,7 +256,7 @@ class BattleUnit : public StateObject<BattleUnit>, public std::enable_shared_fro
 
 	// TU functions
 	// Wether unit can afford action
-	bool canAfford(int cost) const; 
+	bool canAfford(int cost) const;
 	// Returns if unit did spend (false if unsufficient TUs)
 	bool spendTU(int cost);
 

--- a/game/state/battle/battleunit.h
+++ b/game/state/battle/battleunit.h
@@ -105,8 +105,8 @@ class BattleUnit : public StateObject<BattleUnit>, public std::enable_shared_fro
 	int ticksTillNextTargetCheck = 0;
 
 	void setFocus(StateRef<BattleUnit> unit);
-	void startFiring(StateRef<BattleUnit> unit, WeaponStatus status = WeaponStatus::FiringBothHands);
-	void startFiring(Vec3<int> tile, WeaponStatus status = WeaponStatus::FiringBothHands, bool atGround = false);
+	void startAttacking(StateRef<BattleUnit> unit, WeaponStatus status = WeaponStatus::FiringBothHands);
+	void startAttacking(Vec3<int> tile, WeaponStatus status = WeaponStatus::FiringBothHands, bool atGround = false);
 	void stopAttacking();
 
 	// Stats
@@ -236,7 +236,7 @@ class BattleUnit : public StateObject<BattleUnit>, public std::enable_shared_fro
 	// Wether unit is busy - with aiming or firing or otherwise involved
 	bool isBusy() const;
 	// Wether unit is firing its weapon (or aiming in preparation of firing)
-	bool isFiring() const;
+	bool isAttacking() const;
 	// Wether unit is throwing an item
 	bool isThrowing() const;
 
@@ -299,6 +299,6 @@ class BattleUnit : public StateObject<BattleUnit>, public std::enable_shared_fro
 	- ref. to psi attacker (who is controlling it/...)
 	*/
   private:
-	void startFiring(WeaponStatus status);
+	void startAttacking(WeaponStatus status);
 };
 }

--- a/game/state/battle/battleunitanimationpack.cpp
+++ b/game/state/battle/battleunitanimationpack.cpp
@@ -107,6 +107,20 @@ int BattleUnitAnimationPack::getFrameCountHands(StateRef<AEquipmentType> heldIte
 		return 0;
 }
 
+int BattleUnitAnimationPack::getFrameCountFiring(StateRef<AEquipmentType> heldItem, AgentType::BodyState currentBody,
+	AgentType::MovementState movement, Vec2<int> facing)
+{
+	sp<AnimationEntry> e;
+	e = standart_animations[heldItem ? (heldItem->two_handed ? ItemWieldMode::TwoHanded
+		: ItemWieldMode::OneHanded)
+		: ItemWieldMode::None][AgentType::HandState::Firing][movement][currentBody]
+		[facing];
+	if (e)
+		return e->frame_count;
+	else
+		return 0;
+}
+
 void BattleUnitAnimationPack::drawShadow(
     Renderer &r, Vec2<float> screenPosition, StateRef<BattleUnitImagePack> shadow,
     StateRef<AEquipmentType> heldItem, Vec2<int> facing, AgentType::BodyState currentBody,
@@ -149,7 +163,7 @@ void BattleUnitAnimationPack::drawShadow(
 
 	if (e->frames.size() <= frame)
 	{
-		LogError("Frame missing?");
+		LogError("drawShadow: Frame missing?");
 		return;
 	}
 
@@ -189,7 +203,7 @@ void BattleUnitAnimationPack::drawUnit(
 			                                                         : ItemWieldMode::OneHanded)
 			                                 : ItemWieldMode::None][AgentType::HandState::AtEase]
 			                       [movement][currentBody][facing];
-			frame_legs = (distance_travelled * 100 / e->frames_per_100_units) % e_legs->frame_count;
+			frame_legs = (distance_travelled * 100 / e_legs->frames_per_100_units) % e_legs->frame_count;
 		}
 	}
 	else if (currentBody != targetBody)
@@ -237,7 +251,7 @@ void BattleUnitAnimationPack::drawUnit(
 
 	if (e->frames.size() <= frame)
 	{
-		LogError("Frame missing?");
+		LogError("drawUnit: body Frame missing?");
 		return;
 	}
 
@@ -256,7 +270,7 @@ void BattleUnitAnimationPack::drawUnit(
 		{
 			if (e_legs->frames.size() <= frame_legs)
 			{
-				LogError("Frame missing?");
+				LogError("drawUnit: legs Frame missing?");
 				return;
 			}
 			b = &e_legs->frames[frame_legs].unit_image_parts[ie];

--- a/game/state/battle/battleunitanimationpack.cpp
+++ b/game/state/battle/battleunitanimationpack.cpp
@@ -107,14 +107,16 @@ int BattleUnitAnimationPack::getFrameCountHands(StateRef<AEquipmentType> heldIte
 		return 0;
 }
 
-int BattleUnitAnimationPack::getFrameCountFiring(StateRef<AEquipmentType> heldItem, AgentType::BodyState currentBody,
-	AgentType::MovementState movement, Vec2<int> facing)
+int BattleUnitAnimationPack::getFrameCountFiring(StateRef<AEquipmentType> heldItem,
+                                                 AgentType::BodyState currentBody,
+                                                 AgentType::MovementState movement,
+                                                 Vec2<int> facing)
 {
 	sp<AnimationEntry> e;
 	e = standart_animations[heldItem ? (heldItem->two_handed ? ItemWieldMode::TwoHanded
-		: ItemWieldMode::OneHanded)
-		: ItemWieldMode::None][AgentType::HandState::Firing][movement][currentBody]
-		[facing];
+	                                                         : ItemWieldMode::OneHanded)
+	                                 : ItemWieldMode::None][AgentType::HandState::Firing][movement]
+	                       [currentBody][facing];
 	if (e)
 		return e->frame_count;
 	else
@@ -203,7 +205,8 @@ void BattleUnitAnimationPack::drawUnit(
 			                                                         : ItemWieldMode::OneHanded)
 			                                 : ItemWieldMode::None][AgentType::HandState::AtEase]
 			                       [movement][currentBody][facing];
-			frame_legs = (distance_travelled * 100 / e_legs->frames_per_100_units) % e_legs->frame_count;
+			frame_legs =
+			    (distance_travelled * 100 / e_legs->frames_per_100_units) % e_legs->frame_count;
 		}
 	}
 	else if (currentBody != targetBody)

--- a/game/state/battle/battleunitanimationpack.h
+++ b/game/state/battle/battleunitanimationpack.h
@@ -65,11 +65,11 @@ class BattleUnitAnimationPack : public StateObject<BattleUnitAnimationPack>
 	};
 
 	// Animations for cases where current state is equal to target state
-	std::map<ItemWieldMode,
-			  std::map<AgentType::HandState,
-					  std::map<AgentType::MovementState,
-							    std::map<AgentType::BodyState, 
-										std::map<Vec2<int>, sp<AnimationEntry>>>>>>
+	std::map<
+	    ItemWieldMode,
+	    std::map<AgentType::HandState,
+	             std::map<AgentType::MovementState,
+	                      std::map<AgentType::BodyState, std::map<Vec2<int>, sp<AnimationEntry>>>>>>
 	    standart_animations;
 
 	// Animation for changing hand state. First is current, second is target.
@@ -97,11 +97,11 @@ class BattleUnitAnimationPack : public StateObject<BattleUnitAnimationPack>
 	// second parameter is firing angle, which can be +/-1 or +/-2
 	// where + is firing upwards and - is downwards,
 	// 1 is angles 15-30 (degrees) and 2 is 30 and further
-	std::map<ItemWieldMode,
-			  std::map<int,
-					  std::map<AgentType::MovementState,
-								std::map<AgentType::BodyState, 
-										std::map<Vec2<int>, sp<AnimationEntry>>>>>>
+	std::map<
+	    ItemWieldMode,
+	    std::map<int,
+	             std::map<AgentType::MovementState,
+	                      std::map<AgentType::BodyState, std::map<Vec2<int>, sp<AnimationEntry>>>>>>
 	    alt_fire_animations;
 
 	// Animation functions
@@ -118,7 +118,7 @@ class BattleUnitAnimationPack : public StateObject<BattleUnitAnimationPack>
 
 	// Get frame count for animation of hand change. 0 means there's no animation present
 	int getFrameCountFiring(StateRef<AEquipmentType> heldItem, AgentType::BodyState currentBody,
-						   AgentType::MovementState movement, Vec2<int> facing);
+	                        AgentType::MovementState movement, Vec2<int> facing);
 
 	// Draw unit's shadow
 	void drawShadow(Renderer &r, Vec2<float> screenPosition, StateRef<BattleUnitImagePack> shadow,

--- a/game/state/battle/battleunitanimationpack.h
+++ b/game/state/battle/battleunitanimationpack.h
@@ -116,6 +116,10 @@ class BattleUnitAnimationPack : public StateObject<BattleUnitAnimationPack>
 	                       AgentType::HandState currentHands, AgentType::HandState targetHands,
 	                       AgentType::MovementState movement, Vec2<int> facing);
 
+	// Get frame count for animation of hand change. 0 means there's no animation present
+	int getFrameCountFiring(StateRef<AEquipmentType> heldItem, AgentType::BodyState currentBody,
+						   AgentType::MovementState movement, Vec2<int> facing);
+
 	// Draw unit's shadow
 	void drawShadow(Renderer &r, Vec2<float> screenPosition, StateRef<BattleUnitImagePack> shadow,
 	                StateRef<AEquipmentType> heldItem, Vec2<int> facing,

--- a/game/state/battle/battleunitmission.cpp
+++ b/game/state/battle/battleunitmission.cpp
@@ -245,7 +245,8 @@ bool BattleUnitTileHelper::canEnterTile(Tile *from, Tile *to, float &cost, bool 
 			bool fromHasLift = false;
 			if (large)
 			{
-				fromHasLift = from->hasLift || fromX1->hasLift || fromY1->hasLift || fromXY1->hasLift;
+				fromHasLift =
+				    from->hasLift || fromX1->hasLift || fromY1->hasLift || fromXY1->hasLift;
 			}
 			else
 			{
@@ -335,7 +336,7 @@ bool BattleUnitTileHelper::canEnterTile(Tile *from, Tile *to, float &cost, bool 
 			}
 		}
 	}
-	
+
 	// STEP 05: Check if we have enough space for our head upon arrival
 	if (!to->getHeadFits(large, u.agent->type->bodyType->maxHeight))
 		return false;
@@ -434,7 +435,7 @@ bool BattleUnitTileHelper::canEnterTile(Tile *from, Tile *to, float &cost, bool 
 
 				// STEP 06: [For large units if moving: down-right or up-left / SE or NW]
 				// If going down, check that we're not bumping into ground or gravlift on "from"
-				// level 
+				// level
 				if (goingDown)
 				{
 					// Going down-right
@@ -945,8 +946,7 @@ BattleUnitMission *BattleUnitMission::changeStance(BattleUnit &, AgentType::Body
 }
 
 BattleUnitMission *BattleUnitMission::throwItem(BattleUnit &u, sp<AEquipment> item,
-                                                Vec3<int> target, float velocityXY, 
-												float velocityZ)
+                                                Vec3<int> target, float velocityXY, float velocityZ)
 {
 	auto *mission = new BattleUnitMission();
 	mission->type = MissionType::ThrowItem;
@@ -965,27 +965,27 @@ BattleUnitMission *BattleUnitMission::dropItem(BattleUnit &u, sp<AEquipment> ite
 	return mission;
 }
 
-BattleUnitMission *BattleUnitMission::turn(BattleUnit &u, Vec2<int> target, bool free, 
-	bool requireGoal)
+BattleUnitMission *BattleUnitMission::turn(BattleUnit &u, Vec2<int> target, bool free,
+                                           bool requireGoal)
 {
 	auto pos = u.tileObject->getOwningTile()->position;
 	return turn(u, Vec3<int>{pos.x + target.x, pos.y + target.y, pos.z}, free, requireGoal);
 }
 
-BattleUnitMission *BattleUnitMission::turn(BattleUnit &u, Vec3<int> target, bool free, 
-	bool requireGoal)
+BattleUnitMission *BattleUnitMission::turn(BattleUnit &u, Vec3<int> target, bool free,
+                                           bool requireGoal)
 {
 	return turn(u, u.tileObject->getOwningTile()->position, target, free, requireGoal);
 }
 
-BattleUnitMission *BattleUnitMission::turn(BattleUnit &u, Vec3<float> target, bool free, 
-	bool requireGoal)
+BattleUnitMission *BattleUnitMission::turn(BattleUnit &u, Vec3<float> target, bool free,
+                                           bool requireGoal)
 {
 	return turn(u, u.position, target, free, requireGoal);
 }
 
-BattleUnitMission *BattleUnitMission::turn(BattleUnit &u, Vec3<float> from, Vec3<float> to, 
-	bool free, bool requireGoal)
+BattleUnitMission *BattleUnitMission::turn(BattleUnit &u, Vec3<float> from, Vec3<float> to,
+                                           bool free, bool requireGoal)
 {
 	static const std::list<Vec3<float>> angles = {
 	    {0, -1, 0}, {1, -1, 0}, {1, 0, 0},  {1, 1, 0},
@@ -1068,7 +1068,8 @@ bool BattleUnitMission::getNextFacing(GameState &state, BattleUnit &u, Vec2<int>
 	return advanceFacing(state, u, dest);
 }
 
-bool BattleUnitMission::getNextBodyState(GameState &state, BattleUnit &u, AgentType::BodyState &dest)
+bool BattleUnitMission::getNextBodyState(GameState &state, BattleUnit &u,
+                                         AgentType::BodyState &dest)
 {
 	if (this->type != MissionType::ChangeBodyState)
 		return false;
@@ -1231,7 +1232,9 @@ void BattleUnitMission::start(GameState &state, BattleUnit &u)
 				// Check if we can be there
 				auto t = u.tileObject->map.getTile(targetLocation);
 				bool canStand = t->getCanStand(u.isLarge());
-				if (!t->getPassable(u.isLarge(), u.agent->type->bodyType->maxHeight) || t->getUnitIfPresent(true, true, false, nullptr, false, u.isLarge()) || (!u.canFly() && !canStand))
+				if (!t->getPassable(u.isLarge(), u.agent->type->bodyType->maxHeight) ||
+				    t->getUnitIfPresent(true, true, false, nullptr, false, u.isLarge()) ||
+				    (!u.canFly() && !canStand))
 				{
 					return;
 				}
@@ -1258,7 +1261,9 @@ void BattleUnitMission::start(GameState &state, BattleUnit &u)
 				u.missions.clear();
 				u.setPosition(t->getRestingPosition(u.isLarge()));
 				u.resetGoal();
-				AgentType::BodyState targetBodyState = canStand ? AgentType::BodyState::Standing : targetBodyState = AgentType::BodyState::Flying;
+				AgentType::BodyState targetBodyState =
+				    canStand ? AgentType::BodyState::Standing : targetBodyState =
+				                                                    AgentType::BodyState::Flying;
 				if (!u.agent->isBodyStateAllowed(targetBodyState))
 					targetBodyState = AgentType::BodyState::Flying;
 				if (!u.agent->isBodyStateAllowed(targetBodyState))
@@ -1274,7 +1279,7 @@ void BattleUnitMission::start(GameState &state, BattleUnit &u)
 				if (state.battle_common_sample_list->teleport)
 				{
 					fw().soundBackend->playSample(state.battle_common_sample_list->teleport,
-						u.getPosition(), 0.25f);
+					                              u.getPosition(), 0.25f);
 				}
 			}
 			return;
@@ -1308,13 +1313,15 @@ void BattleUnitMission::start(GameState &state, BattleUnit &u)
 				bi->position =
 				    u.position + Vec3<float>{0.0, 0.0, (float)u.getCurrentHeight() / 2.0f / 40.0f};
 				Vec3<float> targetVector = targetLocation - u.tileObject->getOwningTile()->position;
-				
+
 				// FIXME: Apply accuracy!
-				bi->velocity = (glm::normalize(targetVector) * velocityXY +
-				               Vec3<float>{0.0, 0.0, velocityZ}) * VELOCITY_SCALE_BATTLE;
+				bi->velocity =
+				    (glm::normalize(targetVector) * velocityXY + Vec3<float>{0.0, 0.0, velocityZ}) *
+				    VELOCITY_SCALE_BATTLE;
 				bi->supported = false;
 				// 36 / (velocity length) = enough ticks to pass 1 whole tile
-				bi->ownerInvulnerableTicks = (int)ceilf(36.0f / glm::length(bi->velocity / VELOCITY_SCALE_BATTLE)) + 1;
+				bi->ownerInvulnerableTicks =
+				    (int)ceilf(36.0f / glm::length(bi->velocity / VELOCITY_SCALE_BATTLE)) + 1;
 				battle->items.push_back(bi);
 				u.tileObject->map.addObjectToMap(bi);
 
@@ -1341,16 +1348,17 @@ void BattleUnitMission::start(GameState &state, BattleUnit &u)
 						if (u.current_body_state != u.target_body_state)
 						{
 							// body state is changing - wait for it to change and then retry
-							u.missions.emplace(++u.missions.begin(), BattleUnitMission::throwItem(
-							                                             u, item, targetLocation, 
-																		 velocityXY, velocityZ));
-							u.missions.pop_front(); // pop this throw
+							u.missions.emplace(++u.missions.begin(),
+							                   BattleUnitMission::throwItem(u, item, targetLocation,
+							                                                velocityXY, velocityZ));
+							u.missions.pop_front();              // pop this throw
 							u.missions.front()->start(state, u); // re-start body change
 							return;
 						}
 						else // body state is static but not standing
 						{
-							u.addMission(state, BattleUnitMission::changeStance(u, AgentType::BodyState::Standing));
+							u.addMission(state, BattleUnitMission::changeStance(
+							                        u, AgentType::BodyState::Standing));
 							return;
 						}
 					}
@@ -1370,7 +1378,8 @@ void BattleUnitMission::start(GameState &state, BattleUnit &u)
 				// Remove item
 				item->ownerAgent->removeEquipment(item);
 				// Start throw animation
-				u.addMission(state, BattleUnitMission::changeStance(u, AgentType::BodyState::Throwing));
+				u.addMission(state,
+				             BattleUnitMission::changeStance(u, AgentType::BodyState::Throwing));
 				return;
 			}
 			// Throw finished - nothing else to do
@@ -1382,7 +1391,7 @@ void BattleUnitMission::start(GameState &state, BattleUnit &u)
 		case MissionType::DropItem:
 		{
 			if (item)
-			{// Remove item
+			{ // Remove item
 				item->ownerAgent->removeEquipment(item);
 				// Drop item
 				auto battle = u.battle.lock();
@@ -1745,11 +1754,11 @@ bool BattleUnitMission::advanceAlongPath(GameState &state, BattleUnit &u, Vec3<f
 bool BattleUnitMission::advanceFacing(GameState &state, BattleUnit &u, Vec2<int> &dest)
 {
 	static const std::map<Vec2<int>, int> facing_dir_map = {
-		{ { 0, -1 }, 0 },{ { 1, -1 }, 1 },{ { 1, 0 }, 2 },{ { 1, 1 }, 3 },
-		{ { 0, 1 }, 4 },{ { -1, 1 }, 5 },{ { -1, 0 }, 6 },{ { -1, -1 }, 7 } };
+	    {{0, -1}, 0}, {{1, -1}, 1}, {{1, 0}, 2},  {{1, 1}, 3},
+	    {{0, 1}, 4},  {{-1, 1}, 5}, {{-1, 0}, 6}, {{-1, -1}, 7}};
 	static const std::map<int, Vec2<int>> dir_facing_map = {
-		{ 0,{ 0, -1 } },{ 1,{ 1, -1 } },{ 2,{ 1, 0 } },{ 3,{ 1, 1 } },
-		{ 4,{ 0, 1 } },{ 5,{ -1, 1 } },{ 6,{ -1, 0 } },{ 7,{ -1, -1 } } };
+	    {0, {0, -1}}, {1, {1, -1}}, {2, {1, 0}},  {3, {1, 1}},
+	    {4, {0, 1}},  {5, {-1, 1}}, {6, {-1, 0}}, {7, {-1, -1}}};
 
 	if (targetFacing == u.facing)
 		return false;
@@ -1805,15 +1814,16 @@ bool BattleUnitMission::advanceFacing(GameState &state, BattleUnit &u, Vec2<int>
 	int cost = free ? 0 : 1;
 	if (!spendAgentTUs(state, u, cost))
 	{
-		LogWarning("Turning could not start: unsufficient TUs",
-			getName().cStr());
+		LogWarning("Turning could not start: unsufficient TUs", getName().cStr());
 		return false;
 	}
-	
+
 	return true;
 }
 
-bool BattleUnitMission::advanceBodyState(GameState &state, BattleUnit &u, AgentType::BodyState targetState, AgentType::BodyState &dest)
+bool BattleUnitMission::advanceBodyState(GameState &state, BattleUnit &u,
+                                         AgentType::BodyState targetState,
+                                         AgentType::BodyState &dest)
 {
 	if (targetState == u.target_body_state)
 	{
@@ -1827,38 +1837,37 @@ bool BattleUnitMission::advanceBodyState(GameState &state, BattleUnit &u, AgentT
 	// Transition for stance changes
 	// If trying to fly stand up first
 	if (targetState == AgentType::BodyState::Flying &&
-		u.current_body_state != AgentType::BodyState::Standing)
+	    u.current_body_state != AgentType::BodyState::Standing)
 	{
 		return advanceBodyState(state, u, AgentType::BodyState::Standing, dest);
 	}
 	// If trying to stop flying stand up first
 	if (targetState != AgentType::BodyState::Standing &&
-		u.current_body_state == AgentType::BodyState::Flying &&
-		u.agent->isBodyStateAllowed(AgentType::BodyState::Standing))
+	    u.current_body_state == AgentType::BodyState::Flying &&
+	    u.agent->isBodyStateAllowed(AgentType::BodyState::Standing))
 	{
 		return advanceBodyState(state, u, AgentType::BodyState::Standing, dest);
 	}
 	// If trying to stand up from prone go kneel first
 	if (targetState != AgentType::BodyState::Kneeling &&
-		u.current_body_state == AgentType::BodyState::Prone &&
-		u.agent->isBodyStateAllowed(AgentType::BodyState::Kneeling))
+	    u.current_body_state == AgentType::BodyState::Prone &&
+	    u.agent->isBodyStateAllowed(AgentType::BodyState::Kneeling))
 	{
 		return advanceBodyState(state, u, AgentType::BodyState::Kneeling, dest);
 	}
 	// If trying to go prone from not kneeling then kneel first
 	if (targetState == AgentType::BodyState::Prone &&
-		u.current_body_state != AgentType::BodyState::Kneeling &&
-		u.agent->isBodyStateAllowed(AgentType::BodyState::Kneeling))
+	    u.current_body_state != AgentType::BodyState::Kneeling &&
+	    u.agent->isBodyStateAllowed(AgentType::BodyState::Kneeling))
 	{
 		return advanceBodyState(state, u, AgentType::BodyState::Kneeling, dest);
 	}
 	// Calculate and spend cost
 	int cost = getBodyStateChangeCost(u.target_body_state, targetState);
-	
+
 	if (!spendAgentTUs(state, u, cost))
 	{
-		LogWarning("Body state changecould not start: unsufficient TUs",
-			getName().cStr());
+		LogWarning("Body state changecould not start: unsufficient TUs", getName().cStr());
 		return false;
 	}
 	// Change state actually
@@ -1871,34 +1880,34 @@ int BattleUnitMission::getBodyStateChangeCost(AgentType::BodyState from, AgentTy
 	// If not within these conditions, it costs nothing!
 	switch (to)
 	{
-	case AgentType::BodyState::Flying:
-	case AgentType::BodyState::Standing:
-		switch (from)
-		{
-			case AgentType::BodyState::Kneeling:
-				return 8;
-			case AgentType::BodyState::Prone:
-				return 16;
-		}
-		break;
-	case AgentType::BodyState::Kneeling:
-		switch (from)
-		{
-			case AgentType::BodyState::Prone:
-			case AgentType::BodyState::Standing:
-			case AgentType::BodyState::Flying:
-				return 8;
-		}
-		break;
-	case AgentType::BodyState::Prone:
-		switch (from)
-		{
-			case AgentType::BodyState::Kneeling:
-			case AgentType::BodyState::Standing:
-			case AgentType::BodyState::Flying:
-				return 8;
-		}
-		break;
+		case AgentType::BodyState::Flying:
+		case AgentType::BodyState::Standing:
+			switch (from)
+			{
+				case AgentType::BodyState::Kneeling:
+					return 8;
+				case AgentType::BodyState::Prone:
+					return 16;
+			}
+			break;
+		case AgentType::BodyState::Kneeling:
+			switch (from)
+			{
+				case AgentType::BodyState::Prone:
+				case AgentType::BodyState::Standing:
+				case AgentType::BodyState::Flying:
+					return 8;
+			}
+			break;
+		case AgentType::BodyState::Prone:
+			switch (from)
+			{
+				case AgentType::BodyState::Kneeling:
+				case AgentType::BodyState::Standing:
+				case AgentType::BodyState::Flying:
+					return 8;
+			}
+			break;
 	}
 	return 0;
 }
@@ -1936,9 +1945,8 @@ UString BattleUnitMission::getName()
 			                                      this->targetLocation.y, this->targetLocation.z);
 			break;
 		case MissionType::Teleport:
-			name =
-				"Teleport to " + UString::format(" {%d,%d,%d}", this->targetLocation.x,
-					this->targetLocation.y, this->targetLocation.z);
+			name = "Teleport to " + UString::format(" {%d,%d,%d}", this->targetLocation.x,
+			                                        this->targetLocation.y, this->targetLocation.z);
 			break;
 		case MissionType::RestartNextMission:
 			name = "Restart next mission";

--- a/game/state/battle/battleunitmission.h
+++ b/game/state/battle/battleunitmission.h
@@ -43,12 +43,13 @@ class BattleUnitMission
 	bool isFinishedInternal(GameState &state, BattleUnit &u);
 	// INTERNAL: Never called directly
 	static BattleUnitMission *turn(BattleUnit &u, Vec3<float> from, Vec3<float> to, bool free,
-		bool requireGoal);
+	                               bool requireGoal);
 
 	// Methods that calculate next action
 	bool advanceAlongPath(GameState &state, BattleUnit &u, Vec3<float> &dest);
 	bool advanceFacing(GameState &state, BattleUnit &u, Vec2<int> &dest);
-	bool advanceBodyState(GameState &state, BattleUnit &u, AgentType::BodyState targetState, AgentType::BodyState &dest);
+	bool advanceBodyState(GameState &state, BattleUnit &u, AgentType::BodyState targetState,
+	                      AgentType::BodyState &dest);
 
   public:
 	enum class MissionType
@@ -95,11 +96,15 @@ class BattleUnitMission
 	static BattleUnitMission *snooze(BattleUnit &u, unsigned int ticks);
 	static BattleUnitMission *acquireTU(BattleUnit &u, unsigned int tu);
 	static BattleUnitMission *changeStance(BattleUnit &u, AgentType::BodyState state);
-	static BattleUnitMission *throwItem(BattleUnit &u, sp<AEquipment> item, Vec3<int> target, float velocityXY, float velocityZ);
+	static BattleUnitMission *throwItem(BattleUnit &u, sp<AEquipment> item, Vec3<int> target,
+	                                    float velocityXY, float velocityZ);
 	static BattleUnitMission *dropItem(BattleUnit &u, sp<AEquipment> item);
-	static BattleUnitMission *turn(BattleUnit &u, Vec2<int> target, bool free = false, bool requireGoal = true);
-	static BattleUnitMission *turn(BattleUnit &u, Vec3<int> target, bool free = false, bool requireGoal = true);
-	static BattleUnitMission *turn(BattleUnit &u, Vec3<float> target, bool free = false, bool requireGoal = false);
+	static BattleUnitMission *turn(BattleUnit &u, Vec2<int> target, bool free = false,
+	                               bool requireGoal = true);
+	static BattleUnitMission *turn(BattleUnit &u, Vec3<int> target, bool free = false,
+	                               bool requireGoal = true);
+	static BattleUnitMission *turn(BattleUnit &u, Vec3<float> target, bool free = false,
+	                               bool requireGoal = false);
 	static BattleUnitMission *restartNextMission(BattleUnit &u);
 	static BattleUnitMission *fall(BattleUnit &u);
 	static BattleUnitMission *reachGoal(BattleUnit &u);
@@ -144,6 +149,5 @@ class BattleUnitMission
 
 	// ChangeBodyState
 	AgentType::BodyState bodyState = AgentType::BodyState::Downed;
-
 };
 } // namespace OpenApoc

--- a/game/state/battle/battleunitmission.h
+++ b/game/state/battle/battleunitmission.h
@@ -47,8 +47,8 @@ class BattleUnitMission
 
 	// Methods that calculate next action
 	bool advanceAlongPath(GameState &state, BattleUnit &u, Vec3<float> &dest);
-	bool advanceFacing(GameState &state, BattleUnit &u, Vec2<int> &dest, int &ticks);
-	bool advanceBodyState(GameState &state, BattleUnit &u, AgentType::BodyState targetState, AgentType::BodyState &dest, int &ticks);
+	bool advanceFacing(GameState &state, BattleUnit &u, Vec2<int> &dest);
+	bool advanceBodyState(GameState &state, BattleUnit &u, AgentType::BodyState targetState, AgentType::BodyState &dest);
 
   public:
 	enum class MissionType
@@ -76,9 +76,9 @@ class BattleUnitMission
 	// Request next destination
 	bool getNextDestination(GameState &state, BattleUnit &u, Vec3<float> &dest);
 	// Request next facing
-	bool getNextFacing(GameState &state, BattleUnit &u, Vec2<int> &dest, int &ticks);
+	bool getNextFacing(GameState &state, BattleUnit &u, Vec2<int> &dest);
 	// Request next body state
-	bool getNextBodyState(GameState &state, BattleUnit &u, AgentType::BodyState &dest, int &ticks);
+	bool getNextBodyState(GameState &state, BattleUnit &u, AgentType::BodyState &dest);
 
 	// Spend agent TUs or append AcquireTU mission
 	static bool spendAgentTUs(GameState &state, BattleUnit &u, int cost);

--- a/game/state/city/city.cpp
+++ b/game/state/city/city.cpp
@@ -178,6 +178,10 @@ void City::update(GameState &state, unsigned int ticks)
 		{
 			// FIXME: Handle collision
 			this->projectiles.erase(c.projectile);
+			if (c.projectile->impactSfx)
+			{
+				fw().soundBackend->playSample(c.projectile->impactSfx, c.position);
+			}
 			// FIXME: Get doodad from weapon definition?
 			auto doodad = this->placeDoodad({&state, "DOODAD_EXPLOSION_0"}, c.position);
 

--- a/game/state/city/doodad.cpp
+++ b/game/state/city/doodad.cpp
@@ -45,6 +45,8 @@ void Doodad::remove(GameState &state)
 	this->tileObject = nullptr;
 	for (auto &city : state.cities)
 		city.second->doodads.remove(thisPtr);
+	if (state.current_battle)
+		state.current_battle->doodads.remove(thisPtr);
 }
 
 void Doodad::setPosition(Vec3<float> position)

--- a/game/state/city/projectile.cpp
+++ b/game/state/city/projectile.cpp
@@ -15,10 +15,10 @@ const std::map<Projectile::Type, UString> Projectile::TypeMap = {
 
 Projectile::Projectile(StateRef<Vehicle> firer, Vec3<float> position, Vec3<float> velocity,
                        unsigned int lifetime, int damage, unsigned int tail_length,
-                       std::list<sp<Image>> projectile_sprites)
+                       std::list<sp<Image>> projectile_sprites, sp<Sample> impactSfx)
     : type(Type::Beam), position(position), velocity(velocity), age(0), lifetime(lifetime),
       damage(damage), firerVehicle(firer), previousPosition(position), tail_length(tail_length),
-      projectile_sprites(projectile_sprites), velocityScale(VELOCITY_SCALE_CITY)
+      projectile_sprites(projectile_sprites), impactSfx(impactSfx), velocityScale(VELOCITY_SCALE_CITY)
 {
 	// 36 / (velocity length) = enough ticks to pass 1 whole tile
 	ownerInvulnerableTicks = (int)ceilf(36.0f / glm::length(velocity / velocityScale)) + 1;
@@ -26,10 +26,10 @@ Projectile::Projectile(StateRef<Vehicle> firer, Vec3<float> position, Vec3<float
 // FIXME: Properly add unit projectiles and shit
 Projectile::Projectile(StateRef<BattleUnit> firer, Vec3<float> position, Vec3<float> velocity,
                        unsigned int lifetime, int damage, unsigned int tail_length,
-                       std::list<sp<Image>> projectile_sprites)
+                       std::list<sp<Image>> projectile_sprites, sp<Sample> impactSfx)
     : type(Type::Beam), position(position), velocity(velocity), age(0), lifetime(lifetime),
       damage(damage), firerUnit(firer), previousPosition(position), tail_length(tail_length),
-      projectile_sprites(projectile_sprites), velocityScale(VELOCITY_SCALE_BATTLE)
+      projectile_sprites(projectile_sprites), impactSfx(impactSfx), velocityScale(VELOCITY_SCALE_BATTLE)
 {
 	// 36 / (velocity length) = enough ticks to pass 1 whole tile
 	ownerInvulnerableTicks = (int)ceilf(36.0f / glm::length(velocity / velocityScale)) + 1;

--- a/game/state/city/projectile.cpp
+++ b/game/state/city/projectile.cpp
@@ -2,9 +2,9 @@
 #include "game/state/city/city.h"
 #include "game/state/gamestate.h"
 #include "game/state/tileview/collision.h"
+#include "game/state/tileview/tileobject_battleunit.h"
 #include "game/state/tileview/tileobject_projectile.h"
 #include "game/state/tileview/tileobject_vehicle.h"
-#include "game/state/tileview/tileobject_battleunit.h"
 
 namespace OpenApoc
 {
@@ -18,7 +18,8 @@ Projectile::Projectile(StateRef<Vehicle> firer, Vec3<float> position, Vec3<float
                        std::list<sp<Image>> projectile_sprites, sp<Sample> impactSfx)
     : type(Type::Beam), position(position), velocity(velocity), age(0), lifetime(lifetime),
       damage(damage), firerVehicle(firer), previousPosition(position), tail_length(tail_length),
-      projectile_sprites(projectile_sprites), impactSfx(impactSfx), velocityScale(VELOCITY_SCALE_CITY)
+      projectile_sprites(projectile_sprites), impactSfx(impactSfx),
+      velocityScale(VELOCITY_SCALE_CITY)
 {
 	// 36 / (velocity length) = enough ticks to pass 1 whole tile
 	ownerInvulnerableTicks = (int)ceilf(36.0f / glm::length(velocity / velocityScale)) + 1;
@@ -29,7 +30,8 @@ Projectile::Projectile(StateRef<BattleUnit> firer, Vec3<float> position, Vec3<fl
                        std::list<sp<Image>> projectile_sprites, sp<Sample> impactSfx)
     : type(Type::Beam), position(position), velocity(velocity), age(0), lifetime(lifetime),
       damage(damage), firerUnit(firer), previousPosition(position), tail_length(tail_length),
-      projectile_sprites(projectile_sprites), impactSfx(impactSfx), velocityScale(VELOCITY_SCALE_BATTLE)
+      projectile_sprites(projectile_sprites), impactSfx(impactSfx),
+      velocityScale(VELOCITY_SCALE_BATTLE)
 {
 	// 36 / (velocity length) = enough ticks to pass 1 whole tile
 	ownerInvulnerableTicks = (int)ceilf(36.0f / glm::length(velocity / velocityScale)) + 1;
@@ -38,7 +40,8 @@ Projectile::Projectile(StateRef<BattleUnit> firer, Vec3<float> position, Vec3<fl
 Projectile::Projectile()
     : type(Type::Beam), position(0, 0, 0), velocity(0, 0, 0), age(0), lifetime(0), damage(0),
       previousPosition(0, 0, 0), tail_length(0), velocityScale(1, 1, 1)
-{ }
+{
+}
 
 void Projectile::update(GameState &state, unsigned int ticks)
 {
@@ -64,7 +67,8 @@ void Projectile::update(GameState &state, unsigned int ticks)
 		}
 		else
 		{
-			state.current_battle->projectiles.erase(std::dynamic_pointer_cast<Projectile>(this_shared));
+			state.current_battle->projectiles.erase(
+			    std::dynamic_pointer_cast<Projectile>(this_shared));
 		}
 		this->tileObject->removeFromMap();
 		this->tileObject.reset();
@@ -86,12 +90,13 @@ Collision Projectile::checkProjectileCollision(TileMap &map)
 	}
 
 	Collision c = map.findCollision(this->previousPosition, this->position);
-	if (c && ownerInvulnerableTicks > 0 && ((c.obj->getType() == TileObject::Type::Vehicle &&
-	    this->firerVehicle == std::static_pointer_cast<TileObjectVehicle>(c.obj)->getVehicle())
-		|| (c.obj->getType() == TileObject::Type::Unit &&
-			this->firerUnit == std::static_pointer_cast<TileObjectBattleUnit>(c.obj)->getUnit())))
+	if (c && ownerInvulnerableTicks > 0 &&
+	    ((c.obj->getType() == TileObject::Type::Vehicle &&
+	      this->firerVehicle == std::static_pointer_cast<TileObjectVehicle>(c.obj)->getVehicle()) ||
+	     (c.obj->getType() == TileObject::Type::Unit &&
+	      this->firerUnit == std::static_pointer_cast<TileObjectBattleUnit>(c.obj)->getUnit())))
 	{
-		return {}; 
+		return {};
 	}
 
 	c.projectile = shared_from_this();

--- a/game/state/city/projectile.h
+++ b/game/state/city/projectile.h
@@ -14,6 +14,7 @@ class GameState;
 class TileObjectProjectile;
 class TileMap;
 class Collision;
+class Sample;
 
 class Projectile : public std::enable_shared_from_this<Projectile>
 {
@@ -30,10 +31,10 @@ class Projectile : public std::enable_shared_from_this<Projectile>
 	// FIXME: Width is currently just used for drawing - TODO What is "collision" size of beams?
 	Projectile(StateRef<Vehicle> firer, Vec3<float> position, Vec3<float> velocity,
 	           unsigned int lifetime, int damage, unsigned int tail_length,
-	           std::list<sp<Image>> projectile_sprites);
+	           std::list<sp<Image>> projectile_sprites, sp<Sample> impactSfx);
 	Projectile(StateRef<BattleUnit> firer, Vec3<float> position, Vec3<float> velocity,
 	           unsigned int lifetime, int damage, unsigned int tail_length,
-	           std::list<sp<Image>> projectile_sprites);
+	           std::list<sp<Image>> projectile_sprites, sp<Sample> impactSfx);
 	Projectile();
 	virtual void update(GameState &state, unsigned int ticks);
 
@@ -61,6 +62,8 @@ class Projectile : public std::enable_shared_from_this<Projectile>
 
 	unsigned int tail_length;
 	std::list<sp<Image>> projectile_sprites;
+
+	sp<Sample> impactSfx;
 
 	int ownerInvulnerableTicks = 0;
 

--- a/game/state/city/projectile.h
+++ b/game/state/city/projectile.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "game/state/city/vehicle.h"
+#include "game/state/battle/battleunit.h"
 #include "game/state/stateobject.h"
 #include "library/colour.h"
 #include "library/sp.h"
@@ -30,7 +31,7 @@ class Projectile : public std::enable_shared_from_this<Projectile>
 	Projectile(StateRef<Vehicle> firer, Vec3<float> position, Vec3<float> velocity,
 	           unsigned int lifetime, int damage, unsigned int tail_length,
 	           std::list<sp<Image>> projectile_sprites);
-	Projectile(StateRef<Agent> firer, Vec3<float> position, Vec3<float> velocity,
+	Projectile(StateRef<BattleUnit> firer, Vec3<float> position, Vec3<float> velocity,
 	           unsigned int lifetime, int damage, unsigned int tail_length,
 	           std::list<sp<Image>> projectile_sprites);
 	Projectile();
@@ -55,11 +56,13 @@ class Projectile : public std::enable_shared_from_this<Projectile>
 	unsigned int lifetime;
 	int damage;
 	StateRef<Vehicle> firerVehicle;
-	StateRef<Agent> firerAgent;
+	StateRef<BattleUnit> firerUnit;
 	Vec3<float> previousPosition;
 
 	unsigned int tail_length;
 	std::list<sp<Image>> projectile_sprites;
+
+	int ownerInvulnerableTicks = 0;
 
 	Vec3<float> velocityScale;
 

--- a/game/state/city/projectile.h
+++ b/game/state/city/projectile.h
@@ -1,6 +1,6 @@
 #pragma once
-#include "game/state/city/vehicle.h"
 #include "game/state/battle/battleunit.h"
+#include "game/state/city/vehicle.h"
 #include "game/state/stateobject.h"
 #include "library/colour.h"
 #include "library/sp.h"

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -457,7 +457,7 @@ sp<TileObjectVehicle> Vehicle::findClosestEnemy(GameState &state, sp<TileObjectV
 void Vehicle::attackTarget(GameState &state, sp<TileObjectVehicle> vehicleTile,
                            sp<TileObjectVehicle> enemyTile)
 {
-	auto target = enemyTile->getCentrePosition();
+	auto target = enemyTile->getVoxelCentrePosition();
 	float distance = this->tileObject->getDistanceTo(enemyTile);
 
 	for (auto &equipment : this->equipment)

--- a/game/state/city/vehiclemission.h
+++ b/game/state/city/vehiclemission.h
@@ -42,12 +42,14 @@ class VehicleMission
 	bool isTakingOff(Vehicle &v);
 
 	// Methods to create new missions
-	static VehicleMission *gotoLocation(GameState &state, Vehicle &v, Vec3<int> target, bool pickNearest = false);
+	static VehicleMission *gotoLocation(GameState &state, Vehicle &v, Vec3<int> target,
+	                                    bool pickNearest = false);
 	static VehicleMission *gotoPortal(GameState &state, Vehicle &v);
 	static VehicleMission *gotoPortal(GameState &state, Vehicle &v, Vec3<int> target);
 	static VehicleMission *gotoBuilding(GameState &state, Vehicle &v, StateRef<Building> target);
 	static VehicleMission *infiltrateOrSubvertBuilding(GameState &state, Vehicle &v,
-	                                          StateRef<Building> target, bool subvert = false);
+	                                                   StateRef<Building> target,
+	                                                   bool subvert = false);
 	static VehicleMission *attackVehicle(GameState &state, Vehicle &v, StateRef<Vehicle> target);
 	static VehicleMission *followVehicle(GameState &state, Vehicle &v, StateRef<Vehicle> target);
 	static VehicleMission *snooze(GameState &state, Vehicle &v, unsigned int ticks);

--- a/game/state/city/vequipment.cpp
+++ b/game/state/city/vequipment.cpp
@@ -67,9 +67,10 @@ sp<Projectile> VEquipment::fire(Vec3<float> target)
 	velocity = glm::normalize(velocity);
 	velocity *= type->speed;
 
+	// FIXME: Impact sound!
 	return mksp<Projectile>(owner, vehicleTile->getPosition(), velocity,
 	                        static_cast<int>(this->getRange() / type->speed * TICK_SCALE),
-	                        type->damage, type->tail_size, type->projectile_sprites);
+	                        type->damage, type->tail_size, type->projectile_sprites, nullptr);
 }
 
 void VEquipment::update(int ticks)

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -133,8 +133,10 @@ void GameState::initState()
 	}
 	for (auto &a : this->agents)
 	{
-		a.second->leftHandItem = a.second->getFirstItemInSlot(AgentEquipmentLayout::EquipmentSlotType::LeftHand, false);
-		a.second->rightHandItem = a.second->getFirstItemInSlot(AgentEquipmentLayout::EquipmentSlotType::RightHand, false);
+		a.second->leftHandItem =
+		    a.second->getFirstItemInSlot(AgentEquipmentLayout::EquipmentSlotType::LeftHand, false);
+		a.second->rightHandItem =
+		    a.second->getFirstItemInSlot(AgentEquipmentLayout::EquipmentSlotType::RightHand, false);
 	}
 	// Run nessecary methods for different types
 	research.updateTopicList();
@@ -304,7 +306,7 @@ void GameState::fillPlayerStartingProperty()
 					         t->type == AEquipmentType::Type::Grenade)
 					{
 						agent->addEquipmentByType(*this, {this, t->id},
-						                    AgentEquipmentLayout::EquipmentSlotType::General);
+						                          AgentEquipmentLayout::EquipmentSlotType::General);
 					}
 					else
 					{

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -131,6 +131,11 @@ void GameState::initState()
 			w->ammo_types.emplace(this, t.first);
 		}
 	}
+	for (auto &a : this->agents)
+	{
+		a.second->leftHandItem = a.second->getFirstItemInSlot(AgentEquipmentLayout::EquipmentSlotType::LeftHand, false);
+		a.second->rightHandItem = a.second->getFirstItemInSlot(AgentEquipmentLayout::EquipmentSlotType::RightHand, false);
+	}
 	// Run nessecary methods for different types
 	research.updateTopicList();
 }

--- a/game/state/gamestate_serialize.xml
+++ b/game/state/gamestate_serialize.xml
@@ -578,6 +578,7 @@
 		<member>previousPosition</member>
 		<member>tail_length</member>
 		<member>projectile_sprites</member>
+		<member>impactSfx</member>
 		<member>ownerInvulnerableTicks</member>
 		<member>velocityScale</member>
 	</object>

--- a/game/state/gamestate_serialize.xml
+++ b/game/state/gamestate_serialize.xml
@@ -130,10 +130,13 @@
 		<name>AEquipment</name>
 		<member>type</member>
 		<member>equippedPosition</member>
+		<member>equippedSlotType</member>
 		<member>ownerAgent</member>
 		<member>ammo</member>
-		<member>aiming</member>
+		<member>recharge_ticks_accumulated</member>
+		<member>readyToFire</member>
 		<member>weapon_fire_ticks_remaining</member>
+		<member>aimingMode</member>
 	</object>
 	<object>
 		<name>EquipmentSet</name>
@@ -172,6 +175,7 @@
 		<member>home_base</member>
 		<member>owner</member>
 		<member>assigned_to_lab</member>
+		<member>unit</member>
 		<member>equipment</member>
 	</object>
 	<object>
@@ -366,7 +370,7 @@
 		<member>mode</member>
 		<member>player_craft</member>
 		<member type="Section">map_parts</member>
-		<member>units</member>
+		<member type="Section">units</member>
 		<member>items</member>
 		<member>doodads</member>
 		<member>projectiles</member>
@@ -435,6 +439,7 @@
 		<name>BattleCommonImageList</name>
 		<member>strategyImages</member>
 		<member>loadingImage</member>
+		<member>focusArrows</member>
 	</object>
 	<object>
 		<name>BattleCommonSampleList</name>
@@ -478,6 +483,12 @@
 		<member>owner</member>
 		<member>squadNumber</member>
 		<member>squadPosition</member>
+		<member>weaponStatus</member>
+		<member>targetingMode</member>
+		<member>targetTile</member>
+		<member>targetUnit</member>
+		<member>focusUnit</member>
+		<member>ticksTillNextTargetCheck</member>
 		<member>experiencePoints</member>
 		<member>fatalWounds</member>
 		<member>healingBodyPart</member>
@@ -492,6 +503,8 @@
 		<member>current_body_state</member>
 		<member>target_body_state</member>
 		<member>hand_animation_ticks_remaining</member>
+		<member>aiming_ticks_remaining</member>
+		<member>firing_animation_ticks_remaining</member>
 		<member>current_hand_state</member>
 		<member>target_hand_state</member>
 		<member>movement_ticks_passed</member>
@@ -508,8 +521,9 @@
 		<member>retreated</member>
 		<member>destroyed</member>
 		<member>falling</member>
-		<member>fallingQueued</member>
 		<member>fallingSpeed</member>
+		<member>giveWayRequest</member>
+		<member>displayedItem</member>
 	</object>
 	<object>
 		<name>BattleItem</name>
@@ -518,6 +532,7 @@
 		<member>velocity</member>
 		<member>bounced</member>
 		<member>supported</member>
+		<member>ownerInvulnerableTicks</member>
 	</object>
 	<object>
 		<name>BattleMapPart</name>
@@ -559,10 +574,12 @@
 		<member>damage</member>
 		<member>lifetime</member>
 		<member>firerVehicle</member>
-		<member>firerAgent</member>
+		<member>firerUnit</member>
 		<member>previousPosition</member>
 		<member>tail_length</member>
 		<member>projectile_sprites</member>
+		<member>ownerInvulnerableTicks</member>
+		<member>velocityScale</member>
 	</object>
 	<object>
 		<name>Doodad</name>
@@ -1027,6 +1044,20 @@
 		<value>Kneeling</value>
 	</enum>
 	<enum>
+		<name>BattleUnit::WeaponStatus</name>
+		<value>NotFiring</value>
+		<value>FiringLeftHand</value>
+		<value>FiringRightHand</value>
+		<value>FiringBothHands</value>
+	</enum>
+	<enum>
+		<name>BattleUnit::TargetingMode</name>
+		<value>NoTarget</value>
+		<value>Unit</value>
+		<value>TileCenter</value>
+		<value>TileGround</value>
+	</enum>
+	<enum>
 		<name>Organisation::LootPriority</name>
 		<value>A</value>
 		<value>B</value>
@@ -1171,6 +1202,7 @@
 	</enum>
 	<enum>
 		<name>AgentEquipmentLayout::EquipmentSlotType</name>
+		<value>None</value>
 		<value>General</value>
 		<value>ArmorBody</value>
 		<value>ArmorLegs</value>

--- a/game/state/rules/aequipment_rules.cpp
+++ b/game/state/rules/aequipment_rules.cpp
@@ -56,7 +56,6 @@ sp<EquipmentSet> StateObject<EquipmentSet>::get(const GameState &state, const US
 	return it->second;
 }
 
-
 StateRef<AEquipmentType> AEquipment::getPayloadType()
 {
 	if (type->type == AEquipmentType::Type::Weapon && type->ammo_types.size() > 0)

--- a/game/state/rules/aequipment_type.h
+++ b/game/state/rules/aequipment_type.h
@@ -17,7 +17,7 @@ class Image;
 class Sample;
 class AEquipmentType : public StateObject<AEquipmentType>
 {
-  public:
+public:
 	enum class Type
 	{
 		Armor,
@@ -96,11 +96,31 @@ class AEquipmentType : public StateObject<AEquipmentType>
 	std::list<sp<Image>> projectile_sprites;
 	int damage = 0;
 	int accuracy = 0;
+
+	/* This is how many ticks it takes to fire a single shot.
+	*
+	* For fire rate displayed ingame (equipment screen), formula is 1000/FEDL
+	* For example:
+	* Ingame Toxigun has 125, in file it has 8, 125*8=1000.
+	* Ingame Minigun has 83, in file it has 12, 83*12=996. (rounding 1000/12 down makes it 83)
+	*
+	* For fire rate displayed ingame (ufopaedia screen), formula is 36/FEDL
+	* For example:
+	* Ingame Toxigun has 4.50r/s, in file it has 8, 36/8 = 4.5
+	* Ingame Minigun has 3.00r/s, in file it has 12, 36/12 = 3
+	*
+	* Fire rate expects game ticks to be 36 per second
+	* since we have 144 ticks per second, when using this multiply it by 4 to get actual amount
+	* of ticks required to fire
+	*/
 	int fire_delay = 0;
 	int tail_size = 0;
 	bool guided = false;
 	int turn_rate = 0;
+	// Ingame displayed value is this divided by 16 rounded down. Range in tiles
 	int range = 0;
+	float getRange() { return (float)range / 16.0f; };
+	// Projectile's Time To Live, in vanilla ticks (36/sec) (multiply by 4 for OpenApoc ticks)
 	int ttl = 0;
 	int explosion_graphic = 0;
 	sp<Sample> fire_sfx;

--- a/game/state/rules/aequipment_type.h
+++ b/game/state/rules/aequipment_type.h
@@ -17,7 +17,7 @@ class Image;
 class Sample;
 class AEquipmentType : public StateObject<AEquipmentType>
 {
-public:
+  public:
 	enum class Type
 	{
 		Armor,

--- a/game/state/rules/damage_rules.cpp
+++ b/game/state/rules/damage_rules.cpp
@@ -1,5 +1,5 @@
-#include "game/state/gamestate.h"
 #include "game/state/rules/damage.h"
+#include "game/state/gamestate.h"
 
 namespace OpenApoc
 {

--- a/game/state/rules/vehicle_type_rules.cpp
+++ b/game/state/rules/vehicle_type_rules.cpp
@@ -1,5 +1,5 @@
-#include "game/state/gamestate.h"
 #include "game/state/rules/vehicle_type.h"
+#include "game/state/gamestate.h"
 #include "library/sp.h"
 #include "library/strings.h"
 

--- a/game/state/tileview/collision.cpp
+++ b/game/state/tileview/collision.cpp
@@ -11,7 +11,8 @@ namespace OpenApoc
 {
 
 Collision TileMap::findCollision(Vec3<float> lineSegmentStart, Vec3<float> lineSegmentEnd,
-	const std::set<TileObject::Type> validTypes, bool useLOS, bool check_full_path) const
+                                 const std::set<TileObject::Type> validTypes, bool useLOS,
+                                 bool check_full_path) const
 {
 	if (useLOS)
 		LogError("Handle LOS checks");

--- a/game/state/tileview/collision.cpp
+++ b/game/state/tileview/collision.cpp
@@ -11,8 +11,10 @@ namespace OpenApoc
 {
 
 Collision TileMap::findCollision(Vec3<float> lineSegmentStart, Vec3<float> lineSegmentEnd,
-	const std::set<TileObject::Type> validTypes, const sp<TileObject>  owner, bool check_full_path) const
+	const std::set<TileObject::Type> validTypes, bool useLOS, bool check_full_path) const
 {
+	if (useLOS)
+		LogError("Handle LOS checks");
 	bool type_checking = validTypes.size() > 0;
 	Collision c;
 	c.obj = nullptr;
@@ -23,11 +25,8 @@ Collision TileMap::findCollision(Vec3<float> lineSegmentStart, Vec3<float> lineS
 	LineSegment<int, true> line{lineSegmentStartVoxel, lineSegmentEndVoxel};
 	// "point" is thee corrdinate measured in voxel scale units, meaning,
 	// voxel point coordinate within map
-	//LogWarning("Collision from %f %f %f to %f %f %f", lineSegmentStart.x, lineSegmentStart.y, lineSegmentStart.z ,lineSegmentEnd.x, lineSegmentEnd.y, lineSegmentEnd.z);
-	//LogWarning("Voxel from %d %d %d to %d %d %d", lineSegmentStartVoxel.x, lineSegmentStartVoxel.y, lineSegmentStartVoxel.z, lineSegmentEndVoxel.x, lineSegmentEndVoxel.y, lineSegmentEndVoxel.z);
 	for (auto &point : line)
 	{
-//		LogWarning("Checking point %d %d %d", point.x, point.y, point.z);
 		auto tile = point / tileSize;
 		if (tile.x < 0 || tile.x >= size.x || tile.y < 0 || tile.y >= size.y || tile.z < 0 ||
 		    tile.z >= size.z)
@@ -41,8 +40,6 @@ Collision TileMap::findCollision(Vec3<float> lineSegmentStart, Vec3<float> lineS
 		const Tile *t = this->getTile(tile);
 		for (auto &obj : t->intersectingObjects)
 		{
-			if (obj == owner)
-				continue;
 			if (!obj->hasVoxelMap())
 				continue;
 			if (type_checking && validTypes.find(obj->type) == validTypes.end())

--- a/game/state/tileview/pathfinding.cpp
+++ b/game/state/tileview/pathfinding.cpp
@@ -46,8 +46,7 @@ class PathNode
 std::list<Vec3<int>> TileMap::findShortestPath(Vec3<int> origin, Vec3<int> destination,
                                                unsigned int iterationLimit,
                                                const CanEnterTileHelper &canEnterTile,
-											   bool demandGiveWay, float *cost, 
-											   float maxCost)
+                                               bool demandGiveWay, float *cost, float maxCost)
 {
 #ifdef PATHFINDING_DEBUG
 	for (auto &t : tiles)
@@ -195,7 +194,7 @@ std::list<Vec3<int>> TileMap::findShortestPath(Vec3<int> origin, Vec3<int> desti
 					newNodeCost += canEnterTile.adjustCost(nextPosition, z);
 
 					auto newNode = new PathNode(
-					    newNodeCost , canEnterTile.getDistance(nextPosition, goalPosition),
+					    newNodeCost, canEnterTile.getDistance(nextPosition, goalPosition),
 					    nodeToExpand, tile);
 					nodesToDelete.push_back(newNode);
 
@@ -222,13 +221,15 @@ std::list<Vec3<int>> TileMap::findShortestPath(Vec3<int> origin, Vec3<int> desti
 	{
 		if (maxCost > 0.0f)
 		{
-			LogInfo("Could not find path within maxPath, returning closest path {%d,%d,%d}", closestNodeSoFar->thisTile->position.x,
-				closestNodeSoFar->thisTile->position.y, closestNodeSoFar->thisTile->position.z);
+			LogInfo("Could not find path within maxPath, returning closest path {%d,%d,%d}",
+			        closestNodeSoFar->thisTile->position.x, closestNodeSoFar->thisTile->position.y,
+			        closestNodeSoFar->thisTile->position.z);
 		}
 		else
 		{
-			LogError("Surprisingly, no nodes to expand! Closest path {%d,%d,%d}", closestNodeSoFar->thisTile->position.x,
-				closestNodeSoFar->thisTile->position.y, closestNodeSoFar->thisTile->position.z);
+			LogError("Surprisingly, no nodes to expand! Closest path {%d,%d,%d}",
+			         closestNodeSoFar->thisTile->position.x, closestNodeSoFar->thisTile->position.y,
+			         closestNodeSoFar->thisTile->position.z);
 		}
 	}
 

--- a/game/state/tileview/tile.cpp
+++ b/game/state/tileview/tile.cpp
@@ -435,15 +435,16 @@ sp<TileObjectBattleUnit> Tile::getUnitIfPresent() { return firstUnitPresent; }
 
 sp<TileObjectBattleUnit> Tile::getUnitIfPresent(bool onlyConscious, bool mustOccupy,
                                                 bool mustBeStatic,
-                                                sp<TileObjectBattleUnit> exceptThis, bool onlyLarge, bool checkLargeSpace)
+                                                sp<TileObjectBattleUnit> exceptThis, bool onlyLarge,
+                                                bool checkLargeSpace)
 {
 	if (checkLargeSpace)
 	{
 		for (int x = -1; x >= 0; x++)
 		{
-			for (int y = -1; y >= 0;y++)
+			for (int y = -1; y >= 0; y++)
 			{
-				for (int z = 0; z <= 1;z++)
+				for (int z = 0; z <= 1; z++)
 				{
 					if (x == 0 && y == 0 && z == 0)
 					{
@@ -453,7 +454,9 @@ sp<TileObjectBattleUnit> Tile::getUnitIfPresent(bool onlyConscious, bool mustOcc
 					{
 						continue;
 					}
-					auto u = map.getTile(position.x + x, position.y + y, position.z + z)->getUnitIfPresent(onlyConscious, mustOccupy, mustBeStatic, exceptThis, onlyLarge, false);
+					auto u = map.getTile(position.x + x, position.y + y, position.z + z)
+					             ->getUnitIfPresent(onlyConscious, mustOccupy, mustBeStatic,
+					                                exceptThis, onlyLarge, false);
 					if (u)
 					{
 						return u;
@@ -499,13 +502,13 @@ std::list<sp<BattleItem>> Tile::getItems()
 	}
 	for (int x = -1; x <= 1; x++)
 	{
-		for (int y = -1; y <= 1;y++)
+		for (int y = -1; y <= 1; y++)
 		{
 			if (x == 0 && y == 0)
 			{
 				continue;
 			}
-			auto pos = Vec3<int>{ position.x + x, position.y + y, position.z };
+			auto pos = Vec3<int>{position.x + x, position.y + y, position.z};
 			if (pos.x < 0 || pos.x >= map.size.x || pos.y < 0 || pos.y >= map.size.y)
 				continue;
 			auto t = map.getTile(pos);

--- a/game/state/tileview/tile.cpp
+++ b/game/state/tileview/tile.cpp
@@ -337,6 +337,7 @@ void Tile::updateBattlescapeParameters()
 	walkSfx = nullptr;
 	objectDropSfx = nullptr;
 	supportProviderForItems = nullptr;
+	bool groundEncountered = false;
 	closedDoorLeft = false;
 	closedDoorRight = false;
 	for (auto o : ownedObjects)
@@ -693,7 +694,7 @@ sp<Image> TileMap::dumpVoxelView(const Rect<int> viewRect, const TileTransform &
 			auto topPos = transform.screenToTileCoords(Vec2<float>{x, y} + offset, maxZ - 0.01f);
 			auto bottomPos = transform.screenToTileCoords(Vec2<float>{x, y} + offset, 0.0f);
 
-			auto collision = this->findCollision(topPos, bottomPos, {}, nullptr, true);
+			auto collision = this->findCollision(topPos, bottomPos, {}, false, true);
 			if (collision)
 			{
 				if (objectColours.find(collision.obj) == objectColours.end())

--- a/game/state/tileview/tile.h
+++ b/game/state/tileview/tile.h
@@ -221,9 +221,8 @@ class TileMap
 										  float maxCost = 0.0f);
 
 	Collision findCollision(Vec3<float> lineSegmentStart, Vec3<float> lineSegmentEnd,
-					const std::set<TileObject::Type> validTypes = {},
-					const sp<TileObject> owner = nullptr,
-		bool check_full_path = false) const;
+					const std::set<TileObject::Type> validTypes = {}, bool useLOS = false,
+					bool check_full_path = false) const;
 
 	void addObjectToMap(sp<Projectile>);
 	void addObjectToMap(sp<Vehicle>);

--- a/game/state/tileview/tile.h
+++ b/game/state/tileview/tile.h
@@ -217,12 +217,12 @@ class TileMap
 	std::list<Vec3<int>> findShortestPath(Vec3<int> origin, Vec3<int> destination,
 	                                      unsigned int iterationLimit,
 	                                      const CanEnterTileHelper &canEnterTile,
-										  bool demandGiveWay = false, float *cost = nullptr, 
-										  float maxCost = 0.0f);
+	                                      bool demandGiveWay = false, float *cost = nullptr,
+	                                      float maxCost = 0.0f);
 
 	Collision findCollision(Vec3<float> lineSegmentStart, Vec3<float> lineSegmentEnd,
-					const std::set<TileObject::Type> validTypes = {}, bool useLOS = false,
-					bool check_full_path = false) const;
+	                        const std::set<TileObject::Type> validTypes = {}, bool useLOS = false,
+	                        bool check_full_path = false) const;
 
 	void addObjectToMap(sp<Projectile>);
 	void addObjectToMap(sp<Vehicle>);

--- a/game/state/tileview/tileobject_battlemappart.cpp
+++ b/game/state/tileview/tileobject_battlemappart.cpp
@@ -86,10 +86,7 @@ void TileObjectBattleMapPart::removeFromMap()
 		prevDrawOnTile->updateBattlescapeUIDrawOrder();
 	}
 }
-TileObjectBattleMapPart::~TileObjectBattleMapPart()
-{
-	map_part = nullptr;
-}
+TileObjectBattleMapPart::~TileObjectBattleMapPart() { map_part = nullptr; }
 
 TileObjectBattleMapPart::TileObjectBattleMapPart(TileMap &map, sp<BattleMapPart> map_part)
 
@@ -98,20 +95,14 @@ TileObjectBattleMapPart::TileObjectBattleMapPart(TileMap &map, sp<BattleMapPart>
 {
 }
 
-sp<BattleMapPart> TileObjectBattleMapPart::getOwner()
-{
-	return map_part;
-}
+sp<BattleMapPart> TileObjectBattleMapPart::getOwner() { return map_part; }
 
 sp<VoxelMap> TileObjectBattleMapPart::getVoxelMap(Vec3<int>)
 {
 	return this->getOwner()->type->voxelMapLOF;
 }
 
-Vec3<float> TileObjectBattleMapPart::getPosition() const
-{
-	return map_part->getPosition();
-}
+Vec3<float> TileObjectBattleMapPart::getPosition() const { return map_part->getPosition(); }
 
 float TileObjectBattleMapPart::getZOrder() const
 {

--- a/game/state/tileview/tileobject_battleunit.cpp
+++ b/game/state/tileview/tileobject_battleunit.cpp
@@ -45,9 +45,13 @@ void TileObjectBattleUnit::draw(Renderer &r, TileTransform &transform, Vec2<floa
 			if (unit->current_hand_state == AgentType::HandState::Firing)
 			{
 				Vec3<float> targetVector = unit->targetTile - owningTile->position;
-				Vec3<float> targetVectorZeroZ = { targetVector.x, targetVector.y , 0.0f};
-				// Firing angle is 0 for -15..15, +-1  for -30..-15 and 15..30, and 2 for everything else
-				firingAngle = (glm::angle(glm::normalize(targetVector), glm::normalize(targetVectorZeroZ)) * 360 / 2 / M_PI) / 15;
+				Vec3<float> targetVectorZeroZ = {targetVector.x, targetVector.y, 0.0f};
+				// Firing angle is 0 for -15..15, +-1  for -30..-15 and 15..30, and 2 for everything
+				// else
+				firingAngle =
+				    (glm::angle(glm::normalize(targetVector), glm::normalize(targetVectorZeroZ)) *
+				     360 / 2 / M_PI) /
+				    15;
 				if (targetVector.z < 0)
 				{
 					firingAngle = -firingAngle;
@@ -179,7 +183,7 @@ void TileObjectBattleUnit::draw(Renderer &r, TileTransform &transform, Vec2<floa
 void TileObjectBattleUnit::removeFromMap()
 {
 	bool requireRecalc = owningTile != nullptr;
-	std::set<Tile*> prevIntersectingTiles;
+	std::set<Tile *> prevIntersectingTiles;
 	for (auto t : intersectingTiles)
 	{
 		prevIntersectingTiles.insert(t);
@@ -206,7 +210,8 @@ void TileObjectBattleUnit::setPosition(Vec3<float> newPosition)
 	// Set appropriate bounds for the unit
 	auto size = std::max(u->agent->type->bodyType->size[u->current_body_state][u->facing],
 	                     u->agent->type->bodyType->size[u->target_body_state][u->facing]);
-	auto maxHeight = std::max(u->agent->type->bodyType->height[u->current_body_state], u->agent->type->bodyType->height[u->target_body_state]);
+	auto maxHeight = std::max(u->agent->type->bodyType->height[u->current_body_state],
+	                          u->agent->type->bodyType->height[u->target_body_state]);
 	setBounds({size.x, size.y, (float)maxHeight / 40.0f});
 	// It would be appropriate to set bounds based on unit height, like this:
 	//   setBounds({ size.x, size.y, (float)u->agent->type->bodyType->maxHeight / 40.0f });
@@ -222,8 +227,7 @@ void TileObjectBattleUnit::setPosition(Vec3<float> newPosition)
 		if (u->current_body_state == AgentType::BodyState::Prone ||
 		    u->target_body_state == AgentType::BodyState::Prone)
 		{
-			centerOffset = {-u->facing.x * bounds.x / 4.0f, -u->facing.y * bounds.y / 4.0f,
-			                0.5f};
+			centerOffset = {-u->facing.x * bounds.x / 4.0f, -u->facing.y * bounds.y / 4.0f, 0.5f};
 		}
 		else
 		{

--- a/game/state/tileview/tileobject_battleunit.h
+++ b/game/state/tileview/tileobject_battleunit.h
@@ -17,7 +17,7 @@ class TileObjectBattleUnit : public TileObject
 	sp<BattleUnit> getUnit() const;
 
 	// For aiming at the object
-	Vec3<float> getCentrePosition();
+	Vec3<float> getVoxelCentrePosition();
 	Vec3<float> getCenterOffset() const override { return centerOffset; }
 	Vec3<float> centerOffset = {0.0f, 0.0f, 0.0f};
 

--- a/game/state/tileview/tileobject_shadow.cpp
+++ b/game/state/tileview/tileobject_shadow.cpp
@@ -56,7 +56,7 @@ void TileObjectShadow::draw(Renderer &r, TileTransform &transform, Vec2<float> s
 				if (!unit->isConscious() && !unit->falling)
 					break;
 				unit->agent->getAnimationPack()->drawShadow(
-				    r, screenPosition, unit->agent->type->shadow_pack, unit->getDisplayedItem(),
+				    r, screenPosition, unit->agent->type->shadow_pack, unit->displayedItem,
 				    unit->facing, unit->current_body_state, unit->target_body_state,
 				    unit->current_hand_state, unit->target_hand_state,
 				    unit->usingLift ? AgentType::MovementState::None : unit->current_movement_state,

--- a/game/state/tileview/tileobject_vehicle.cpp
+++ b/game/state/tileview/tileobject_vehicle.cpp
@@ -110,7 +110,7 @@ TileObjectVehicle::TileObjectVehicle(TileMap &map, sp<Vehicle> vehicle)
 	animationFrame = vehicle->type->animation_sprites.begin();
 }
 
-Vec3<float> TileObjectVehicle::getCentrePosition()
+Vec3<float> TileObjectVehicle::getVoxelCentrePosition()
 {
 	auto vtype = this->getVehicle()->type;
 

--- a/game/state/tileview/tileobject_vehicle.h
+++ b/game/state/tileview/tileobject_vehicle.h
@@ -21,7 +21,7 @@ class TileObjectVehicle : public TileObject
 		this->getVehicle()->velocity = dir;
 	}
 
-	Vec3<float> getCentrePosition();
+	Vec3<float> getVoxelCentrePosition();
 	bool hasVoxelMap() override { return true; }
 	sp<VoxelMap> getVoxelMap(Vec3<int> mapIndex) override;
 	Vec3<float> getPosition() const override;

--- a/game/ui/battle/battleview.cpp
+++ b/game/ui/battle/battleview.cpp
@@ -1,13 +1,13 @@
 #include "game/ui/battle/battleview.h"
 #include "forms/ui.h"
+#include "framework/apocresources/cursor.h"
 #include "framework/event.h"
 #include "framework/framework.h"
-#include "framework/apocresources/cursor.h"
 #include "game/state/battle/battle.h"
+#include "game/state/battle/battleitem.h"
 #include "game/state/battle/battlemappart.h"
 #include "game/state/battle/battlemappart_type.h"
 #include "game/state/battle/battleunit.h"
-#include "game/state/battle/battleitem.h"
 #include "game/state/gameevent.h"
 #include "game/state/tileview/collision.h"
 #include "game/state/tileview/tileobject_battlemappart.h"
@@ -30,18 +30,18 @@ static const std::vector<UString> TAB_FORM_NAMES_TB = {
 } // anonymous namespace
 
 BattleView::BattleView(sp<GameState> state)
-    : BattleTileView(
-          *state->current_battle->map, Vec3<int>{TILE_X_BATTLE, TILE_Y_BATTLE, TILE_Z_BATTLE},
-          Vec2<int>{STRAT_TILE_X, STRAT_TILE_Y}, TileViewMode::Isometric,
-          state->current_battle->battleviewZLevel, state->current_battle->battleviewScreenCenter,
-		state->current_battle),
+    : BattleTileView(*state->current_battle->map,
+                     Vec3<int>{TILE_X_BATTLE, TILE_Y_BATTLE, TILE_Z_BATTLE},
+                     Vec2<int>{STRAT_TILE_X, STRAT_TILE_Y}, TileViewMode::Isometric,
+                     state->current_battle->battleviewZLevel,
+                     state->current_battle->battleviewScreenCenter, state->current_battle),
       baseForm(ui().getForm("FORM_BATTLE_UI")), state(state), followAgent(false),
       palette(fw().data->loadPalette("xcom3/tacdata/tactical.pal")),
       selectionState(BattleSelectionState::Normal)
 {
 	this->pal = palette;
 
-	for (int j = 0; j<=15; j++)
+	for (int j = 0; j <= 15; j++)
 	{
 		colorCurrent = j;
 		auto newPal = mksp<Palette>();
@@ -51,27 +51,27 @@ BattleView::BattleView(sp<GameState> state)
 			newPal->setColour(i, palette->getColour(i));
 		}
 		// Lift color, pulsates from (0r 3/8g 5/8b) to (0r 8/8g 4/8b)
-		newPal->setColour(
-			255 - 4, Colour(0, (colorCurrent * 16 * 5 + 255 * 3) / 8, (colorCurrent * 16 * -1 + 255 * 5) / 8));
+		newPal->setColour(255 - 4, Colour(0, (colorCurrent * 16 * 5 + 255 * 3) / 8,
+		                                  (colorCurrent * 16 * -1 + 255 * 5) / 8));
 		// Red color, for enemy indicators, pulsates from (3/8r 0g 0b) to (8/8r 0g 0b)
 		newPal->setColour(255 - 3, Colour((colorCurrent * 16 * 5 + 255 * 3) / 8, 0, 0));
 		// Blue color, for misc. indicators, pulsates from (0r 3/8g 3/8b) to (0r 8/8g 8/8b)
-		newPal->setColour(
-			255 - 2, Colour(0, (colorCurrent * 16 * 5 + 255 * 3) / 8, (colorCurrent * 16 * 5 + 255 * 3) / 8));
+		newPal->setColour(255 - 2, Colour(0, (colorCurrent * 16 * 5 + 255 * 3) / 8,
+		                                  (colorCurrent * 16 * 5 + 255 * 3) / 8));
 		// Pink color, for neutral indicators, pulsates from (3/8r 0g 3/8b) to (8/8r 0g 8/8b)
-		newPal->setColour(
-			255 - 1, Colour((colorCurrent * 16 * 5 + 255 * 3) / 8, 0, (colorCurrent * 16 * 5 + 255 * 3) / 8));
+		newPal->setColour(255 - 1, Colour((colorCurrent * 16 * 5 + 255 * 3) / 8, 0,
+		                                  (colorCurrent * 16 * 5 + 255 * 3) / 8));
 		// Yellow color, for owned indicators, pulsates from (3/8r 3/8g 0b) to (8/8r 8/8g 0b)
-		newPal->setColour(
-			255 - 0, Colour((colorCurrent * 16 * 5 + 255 * 3) / 8, (colorCurrent * 16 * 5 + 255 * 3) / 8, 0));
+		newPal->setColour(255 - 0, Colour((colorCurrent * 16 * 5 + 255 * 3) / 8,
+		                                  (colorCurrent * 16 * 5 + 255 * 3) / 8, 0));
 
 		modPalette.push_back(newPal);
 	}
 
 	selectedItemOverlay = fw().data->loadImage("battle/battle-item-select-icon.png");
 	pauseIcon = fw().data->loadImage(UString::format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-		"icons.tab:%d:xcom3/tacdata/tactical.pal",
-		260));
+	                                                 "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                                 260));
 
 	for (auto &formName : TAB_FORM_NAMES_RT)
 	{
@@ -392,17 +392,17 @@ BattleView::BattleView(sp<GameState> state)
 
 	// We need this in TB because we will be able to allow pausing then
 	this->baseForm->findControl("BUTTON_SPEED0")
-		->addCallback(FormEventType::CheckBoxSelected,
-			[this](Event *) { this->updateSpeed = BattleUpdateSpeed::Pause; });
+	    ->addCallback(FormEventType::CheckBoxSelected,
+	                  [this](Event *) { this->updateSpeed = BattleUpdateSpeed::Pause; });
 	this->baseForm->findControl("BUTTON_SPEED1")
-		->addCallback(FormEventType::CheckBoxSelected,
-			[this](Event *) { this->updateSpeed = BattleUpdateSpeed::Speed1; });
+	    ->addCallback(FormEventType::CheckBoxSelected,
+	                  [this](Event *) { this->updateSpeed = BattleUpdateSpeed::Speed1; });
 	this->baseForm->findControl("BUTTON_SPEED2")
-		->addCallback(FormEventType::CheckBoxSelected,
-			[this](Event *) { this->updateSpeed = BattleUpdateSpeed::Speed2; });
+	    ->addCallback(FormEventType::CheckBoxSelected,
+	                  [this](Event *) { this->updateSpeed = BattleUpdateSpeed::Speed2; });
 	this->baseForm->findControl("BUTTON_SPEED3")
-		->addCallback(FormEventType::CheckBoxSelected,
-			[this](Event *) { this->updateSpeed = BattleUpdateSpeed::Speed3; });
+	    ->addCallback(FormEventType::CheckBoxSelected,
+	                  [this](Event *) { this->updateSpeed = BattleUpdateSpeed::Speed3; });
 
 	switch (state->current_battle->mode)
 	{
@@ -416,8 +416,8 @@ BattleView::BattleView(sp<GameState> state)
 			this->baseForm->findControl("BUTTON_SPEED3")->Visible = false;
 			this->baseForm->findControl("CLOCK")->Visible = false;
 			this->baseForm->findControl("BUTTON_ENDTURN")
-				->addCallback(FormEventType::ButtonClick,
-					[this](Event *) { this->state->current_battle->endTurn();});
+			    ->addCallback(FormEventType::ButtonClick,
+			                  [this](Event *) { this->state->current_battle->endTurn(); });
 			break;
 		default:
 			LogError("Unexpected battle mode \"%d\"", (int)state->current_battle->mode);
@@ -463,7 +463,7 @@ void BattleView::render()
 		pauseIconTimer %= PAUSE_ICON_BLINK_TIME * 2;
 		if (updateSpeed == BattleUpdateSpeed::Pause && pauseIconTimer > PAUSE_ICON_BLINK_TIME)
 		{
-			fw().renderer->draw(pauseIcon, { fw().displayGetSize().x - pauseIcon->size.x , 0.0f });
+			fw().renderer->draw(pauseIcon, {fw().displayGetSize().x - pauseIcon->size.x, 0.0f});
 		}
 	}
 
@@ -661,14 +661,14 @@ void BattleView::updateSelectionMode()
 	}
 	else
 	{
-		if (selectionState == BattleSelectionState::ThrowLeft 
-			|| selectionState == BattleSelectionState::ThrowRight 
-			|| selectionState == BattleSelectionState::TeleportLeft 
-			|| selectionState == BattleSelectionState::TeleportRight 
-			|| selectionState == BattleSelectionState::PsiLeft
-			|| selectionState == BattleSelectionState::PsiRight
-			|| selectionState == BattleSelectionState::FireLeft
-			|| selectionState == BattleSelectionState::FireRight)
+		if (selectionState == BattleSelectionState::ThrowLeft ||
+		    selectionState == BattleSelectionState::ThrowRight ||
+		    selectionState == BattleSelectionState::TeleportLeft ||
+		    selectionState == BattleSelectionState::TeleportRight ||
+		    selectionState == BattleSelectionState::PsiLeft ||
+		    selectionState == BattleSelectionState::PsiRight ||
+		    selectionState == BattleSelectionState::FireLeft ||
+		    selectionState == BattleSelectionState::FireRight)
 		{
 			// Cannot cancel out of action here
 		}
@@ -712,45 +712,45 @@ void BattleView::updateSelectionMode()
 	// Change cursor
 	switch (selectionState)
 	{
-	case BattleSelectionState::FireAny:
-	case BattleSelectionState::FireLeft:
-	case BattleSelectionState::FireRight:
-		fw().getCursor().CurrentType = ApocCursor::CursorType::Shoot;
-		break;
-	case BattleSelectionState::ThrowLeft:
-	case BattleSelectionState::ThrowRight:
-		if (actionImpossibleDelay > 0)
-		{
-			fw().getCursor().CurrentType = ApocCursor::CursorType::NoTarget;
-		}
-		else
-		{
-			fw().getCursor().CurrentType = ApocCursor::CursorType::ThrowTarget;
-		}
-		break;
-	case BattleSelectionState::PsiLeft:
-	case BattleSelectionState::PsiRight:
-		fw().getCursor().CurrentType = ApocCursor::CursorType::PsiTarget;
-		break;
-	case BattleSelectionState::Normal:
-	case BattleSelectionState::NormalAlt:
-		fw().getCursor().CurrentType = ApocCursor::CursorType::Normal;
-		break;
-	case BattleSelectionState::NormalCtrl:
-	case BattleSelectionState::NormalCtrlAlt:
-		fw().getCursor().CurrentType = ApocCursor::CursorType::Add;
-		break;
-	case BattleSelectionState::TeleportLeft:
-	case BattleSelectionState::TeleportRight:
-		if (actionImpossibleDelay > 0)
-		{
-			fw().getCursor().CurrentType = ApocCursor::CursorType::NoTeleport;
-		}
-		else
-		{
-			fw().getCursor().CurrentType = ApocCursor::CursorType::Teleport;
-		}
-		break;
+		case BattleSelectionState::FireAny:
+		case BattleSelectionState::FireLeft:
+		case BattleSelectionState::FireRight:
+			fw().getCursor().CurrentType = ApocCursor::CursorType::Shoot;
+			break;
+		case BattleSelectionState::ThrowLeft:
+		case BattleSelectionState::ThrowRight:
+			if (actionImpossibleDelay > 0)
+			{
+				fw().getCursor().CurrentType = ApocCursor::CursorType::NoTarget;
+			}
+			else
+			{
+				fw().getCursor().CurrentType = ApocCursor::CursorType::ThrowTarget;
+			}
+			break;
+		case BattleSelectionState::PsiLeft:
+		case BattleSelectionState::PsiRight:
+			fw().getCursor().CurrentType = ApocCursor::CursorType::PsiTarget;
+			break;
+		case BattleSelectionState::Normal:
+		case BattleSelectionState::NormalAlt:
+			fw().getCursor().CurrentType = ApocCursor::CursorType::Normal;
+			break;
+		case BattleSelectionState::NormalCtrl:
+		case BattleSelectionState::NormalCtrlAlt:
+			fw().getCursor().CurrentType = ApocCursor::CursorType::Add;
+			break;
+		case BattleSelectionState::TeleportLeft:
+		case BattleSelectionState::TeleportRight:
+			if (actionImpossibleDelay > 0)
+			{
+				fw().getCursor().CurrentType = ApocCursor::CursorType::NoTeleport;
+			}
+			else
+			{
+				fw().getCursor().CurrentType = ApocCursor::CursorType::Teleport;
+			}
+			break;
 	}
 	actionImpossibleDelay--;
 }
@@ -843,11 +843,12 @@ void BattleView::updateSoldierButtons()
 
 	bool throwing = !selectedUnits.empty() && selectedUnits.front()->isThrowing();
 	this->activeTab->findControlTyped<CheckBox>("BUTTON_LEFT_HAND_THROW")
-	    ->setChecked(selectionState == BattleSelectionState::ThrowLeft || leftThrowDelay > 0 || throwing);
+	    ->setChecked(selectionState == BattleSelectionState::ThrowLeft || leftThrowDelay > 0 ||
+	                 throwing);
 	this->activeTab->findControlTyped<CheckBox>("BUTTON_RIGHT_HAND_THROW")
-	    ->setChecked(selectionState == BattleSelectionState::ThrowRight || rightThrowDelay > 0 || throwing);
+	    ->setChecked(selectionState == BattleSelectionState::ThrowRight || rightThrowDelay > 0 ||
+	                 throwing);
 }
-
 
 // Calculate starting velocity among z to reach target
 bool calculateVelocityForThrow(float distanceXY, float diffZ, float &velocityXY, float &velocityZ)
@@ -866,14 +867,14 @@ bool calculateVelocityForThrow(float distanceXY, float diffZ, float &velocityXY,
 	}
 
 	// For simplicity assume moving only along X
-	// 
+	//
 	// t = time, in ticks
 	// VelocityZ(t) = VelocityZ0 - (Falling_Acceleration / VELOCITY_SCALE_Z) * t;
-	// Let:	a = -Faclling_acc / VELOCITY_SCALE_Z/ 2 / TICK_SCALE, 
-	//		b = a + VelocityZ / TICK_SCALE, 
+	// Let:	a = -Faclling_acc / VELOCITY_SCALE_Z/ 2 / TICK_SCALE,
+	//		b = a + VelocityZ / TICK_SCALE,
 	//		c = diffZ
 	// z(t) = a*t^2 + b*t + c
-	// 
+	//
 	// x = coordinate on the tile grid, in tiles
 	// x = t * VelocityX / TICK_SCALE
 	// t = x * TICK_SCALE / VelocityX
@@ -892,12 +893,13 @@ bool calculateVelocityForThrow(float distanceXY, float diffZ, float &velocityXY,
 	float c = diffZ;
 	float t = 0.0f;
 
-	// We will continue reducing velocityXY  until we find such a trajectory that makes the item fall on top of the tile
+	// We will continue reducing velocityXY  until we find such a trajectory that makes the item
+	// fall on top of the tile
 	while (velocityXY > 0.0f)
 	{
 		// FIXME: Should we prevent very high Z-trajectories, unreallistic for heavy items?
 		t = distanceXY * TICK_SCALE / (velocityXY);
-		velocityZ = TICK_SCALE * ((-c - a*t*t) / t - a);
+		velocityZ = TICK_SCALE * ((-c - a * t * t) / t - a);
 		if (velocityZ - (FALLING_ACCELERATION_ITEM / VELOCITY_SCALE_BATTLE.z) * t < -0.5f)
 		{
 			return true;
@@ -910,14 +912,18 @@ bool calculateVelocityForThrow(float distanceXY, float diffZ, float &velocityXY,
 	return false;
 }
 
-// Checks if, while going along the trajectory, we reach target tile or get first collision within it's boundaries
-bool checkThrowTrajectoryValid(TileMap &map, const sp<TileObject> thrower, Vec3<float> start, Vec3<int> end, Vec3<float> targetVector, float velocityXY, float velocityZ)
+// Checks if, while going along the trajectory, we reach target tile or get first collision within
+// it's boundaries
+bool checkThrowTrajectoryValid(TileMap &map, const sp<TileObject> thrower, Vec3<float> start,
+                               Vec3<int> end, Vec3<float> targetVector, float velocityXY,
+                               float velocityZ)
 {
 	int iterationsPerCollision = 10;
 	Vec3<float> curPos = start;
 	Vec3<float> newPos;
-	Vec3<float> velocity = (glm::normalize(targetVector) * velocityXY +
-		Vec3<float>{0.0, 0.0, velocityZ}) * VELOCITY_SCALE_BATTLE;
+	Vec3<float> velocity =
+	    (glm::normalize(targetVector) * velocityXY + Vec3<float>{0.0, 0.0, velocityZ}) *
+	    VELOCITY_SCALE_BATTLE;
 	Collision c;
 	do
 	{
@@ -1090,26 +1096,33 @@ void BattleView::orderThrow(Vec3<int> target, bool right)
 	{
 		return;
 	}
-	
+
 	// Check distance to target
 	auto pos = unit->tileObject->getOwningTile()->position;
 	Vec3<float> targetVector = target - pos;
-	targetVector = { targetVector.x, targetVector.y, 0.0f };
+	targetVector = {targetVector.x, targetVector.y, 0.0f};
 	float distance = glm::length(targetVector);
-	if (distance >= unit->getMaxThrowDistance(item->type->weight + (item->payloadType ? item->payloadType->weight : 0), pos.z - target.z))
+	if (distance >= unit->getMaxThrowDistance(
+	                    item->type->weight + (item->payloadType ? item->payloadType->weight : 0),
+	                    pos.z - target.z))
 	{
 		actionImpossibleDelay = 40;
 		return;
 	}
 
 	// Calculate trajectory
-	Vec3<float> startPos = { unit->position.x, unit->position.y, unit->position.z + (float)unit->agent->type->bodyType->height[AgentType::BodyState::Throwing] / 2.0f / 40.0f };
+	Vec3<float> startPos = {
+	    unit->position.x, unit->position.y,
+	    unit->position.z +
+	        (float)unit->agent->type->bodyType->height[AgentType::BodyState::Throwing] / 2.0f /
+	            40.0f};
 	float velXY = 0.0f;
 	float velZ = 0.0f;
 	bool valid = true;
 	while (calculateVelocityForThrow(distance, startPos.z - target.z - 6.0f / 40.0f, velXY, velZ))
 	{
-		valid = checkThrowTrajectoryValid(map, unit->tileObject, startPos, target, targetVector, velXY, velZ);
+		valid = checkThrowTrajectoryValid(map, unit->tileObject, startPos, target, targetVector,
+		                                  velXY, velZ);
 		if (valid)
 		{
 			break;
@@ -1152,7 +1165,7 @@ void BattleView::orderDrop(bool right)
 		unit->missions.emplace_front(BattleUnitMission::dropItem(*unit, item));
 		unit->missions.front()->start(*this->state, *unit);
 		LogWarning("BattleUnit \"%s\" dropping item in %s hand", unit->agent->name.cStr(),
-			right ? "right" : "left");
+		           right ? "right" : "left");
 	}
 	else
 	{
@@ -1168,8 +1181,9 @@ void BattleView::orderDrop(bool right)
 			return;
 		}
 		auto item = items.front();
-		unit->agent->addEquipment(*state, item->item, right ? AgentEquipmentLayout::EquipmentSlotType::RightHand
-			: AgentEquipmentLayout::EquipmentSlotType::LeftHand);
+		unit->agent->addEquipment(*state, item->item,
+		                          right ? AgentEquipmentLayout::EquipmentSlotType::RightHand
+		                                : AgentEquipmentLayout::EquipmentSlotType::LeftHand);
 		item->die(*state, false);
 	}
 }
@@ -1237,13 +1251,13 @@ void BattleView::orderTeleport(Vec3<int> target, bool right)
 	}
 	auto unit = selectedUnits.front();
 	auto item =
-		unit->agent->getFirstItemInSlot(right ? AgentEquipmentLayout::EquipmentSlotType::RightHand
-			: AgentEquipmentLayout::EquipmentSlotType::LeftHand);
+	    unit->agent->getFirstItemInSlot(right ? AgentEquipmentLayout::EquipmentSlotType::RightHand
+	                                          : AgentEquipmentLayout::EquipmentSlotType::LeftHand);
 
 	// FIXME: REMOVE TEMPORARY CHEAT
 	item = mksp<AEquipment>();
 	UString tp = "AEQUIPMENTTYPE_PERSONAL_TELEPORTER";
-	item->type = { &*state, tp };
+	item->type = {&*state, tp};
 	item->ammo = item->type->max_ammo;
 	// FIXME: REMOVE TEMPORARY CHEAT
 
@@ -1258,13 +1272,13 @@ void BattleView::orderTeleport(Vec3<int> target, bool right)
 	if (m->item)
 	{
 		actionImpossibleDelay = 40;
-		LogWarning("BattleUnit \"%s\" could not teleport using item in %s hand ", unit->agent->name.cStr(),
-			right ? "right" : "left");
+		LogWarning("BattleUnit \"%s\" could not teleport using item in %s hand ",
+		           unit->agent->name.cStr(), right ? "right" : "left");
 	}
 	else
 	{
 		LogWarning("BattleUnit \"%s\" teleported using item in %s hand ", unit->agent->name.cStr(),
-			right ? "right" : "left");
+		           right ? "right" : "left");
 		selectionState = BattleSelectionState::Normal;
 	}
 }
@@ -1371,12 +1385,12 @@ void BattleView::eventOccurred(Event *e)
 	}
 	else if (e->type() == EVENT_MOUSE_MOVE)
 	{
-		Vec2<float> screenOffset = { this->getScreenOffset().x, this->getScreenOffset().y };
+		Vec2<float> screenOffset = {this->getScreenOffset().x, this->getScreenOffset().y};
 		// Offset by 4 since ingame 4 is the typical height of the ground, and game displays cursor
 		// on top of the ground
 		setSelectedTilePosition(this->screenToTileCoords(
-			Vec2<float>((float)e->mouse().X, (float)e->mouse().Y + 4) - screenOffset,
-			(float)getZLevel() - 1.0f));
+		    Vec2<float>((float)e->mouse().X, (float)e->mouse().Y + 4) - screenOffset,
+		    (float)getZLevel() - 1.0f));
 	}
 	else if (e->type() == EVENT_KEY_UP &&
 	         (e->keyboard().KeyCode == SDLK_RSHIFT || e->keyboard().KeyCode == SDLK_LSHIFT ||
@@ -1424,7 +1438,7 @@ void BattleView::eventOccurred(Event *e)
 			this->setScreenCenterTile({clickTile.x, clickTile.y});
 		}
 		else if (e->type() == EVENT_MOUSE_DOWN &&
-			(Event::isPressed(e->mouse().Button, Event::MouseButton::Middle)))
+		         (Event::isPressed(e->mouse().Button, Event::MouseButton::Middle)))
 		{
 			// CHEAT - move unit to mouse
 			if (!selectedUnits.empty())
@@ -1437,7 +1451,8 @@ void BattleView::eventOccurred(Event *e)
 		          Event::isPressed(e->mouse().Button, Event::MouseButton::Right)))
 		{
 			auto buttonPressed = Event::isPressed(e->mouse().Button, Event::MouseButton::Left)
-				? Event::MouseButton::Left : Event::MouseButton::Right;
+			                         ? Event::MouseButton::Left
+			                         : Event::MouseButton::Right;
 
 			// If a click has not been handled by a form it's in the map.
 			auto t = this->getSelectedTilePosition();
@@ -1459,7 +1474,8 @@ void BattleView::eventOccurred(Event *e)
 					{
 						case Event::MouseButton::Left:
 							// If unit is present, priority is to move if not occupied
-							if (unitPresent && unitPresent->owner == state->current_battle->currentPlayer)
+							if (unitPresent &&
+							    unitPresent->owner == state->current_battle->currentPlayer)
 							{
 								// Move if units are selected and noone is occupying
 								if (!unitOccupying && selectedUnits.size() > 0)
@@ -1483,7 +1499,8 @@ void BattleView::eventOccurred(Event *e)
 						case Event::MouseButton::Right:
 							// Turn if no enemy unit present under cursor
 							// or if holding alt
-							if (!unitPresent || unitPresent->owner == state->current_battle->currentPlayer ||
+							if (!unitPresent ||
+							    unitPresent->owner == state->current_battle->currentPlayer ||
 							    selectionState == BattleSelectionState::NormalAlt)
 							{
 								orderTurn(t);
@@ -1493,18 +1510,18 @@ void BattleView::eventOccurred(Event *e)
 							{
 								switch (state->current_battle->mode)
 								{
-								case Battle::Mode::TurnBased:
-									if (unitOccupying)
-									{
-										orderFire({ &*state, unitOccupying->id });
-									}
-									break;
-								case Battle::Mode::RealTime:
-									if (unitPresent->isConscious())
-									{
-										orderFocus({ &*state, unitPresent->id });
-									}
-									break;
+									case Battle::Mode::TurnBased:
+										if (unitOccupying)
+										{
+											orderFire({&*state, unitOccupying->id});
+										}
+										break;
+									case Battle::Mode::RealTime:
+										if (unitPresent->isConscious())
+										{
+											orderFocus({&*state, unitPresent->id});
+										}
+										break;
 								}
 							}
 							break;
@@ -1516,7 +1533,8 @@ void BattleView::eventOccurred(Event *e)
 					{
 						// LMB = Add to selection
 						case Event::MouseButton::Left:
-							if (unitPresent && unitPresent->owner == state->current_battle->currentPlayer)
+							if (unitPresent &&
+							    unitPresent->owner == state->current_battle->currentPlayer)
 							{
 								orderSelect(unitPresent, false, true);
 							}
@@ -1524,14 +1542,15 @@ void BattleView::eventOccurred(Event *e)
 							else if (!unitOccupying &&
 							         selectionState != BattleSelectionState::NormalCtrl)
 							{
-								//selectionState == BattleSelectionState::NormalCtrlAlt)
+								// selectionState == BattleSelectionState::NormalCtrlAlt)
 								// Move pathing through
 								orderMove(t, 0, true);
 							}
 							break;
 						// RMB = Remove from selection
 						case Event::MouseButton::Right:
-							if (unitPresent && unitPresent->owner == state->current_battle->currentPlayer)
+							if (unitPresent &&
+							    unitPresent->owner == state->current_battle->currentPlayer)
 							{
 								orderSelect(unitPresent, true);
 							}
@@ -1543,38 +1562,41 @@ void BattleView::eventOccurred(Event *e)
 				case BattleSelectionState::FireRight:
 					switch (buttonPressed)
 					{
-					case Event::MouseButton::Left:
-					{
-						BattleUnit::WeaponStatus status = BattleUnit::WeaponStatus::FiringBothHands;
-						switch (selectionState)
+						case Event::MouseButton::Left:
 						{
-						case BattleSelectionState::FireLeft:
-							status = BattleUnit::WeaponStatus::FiringLeftHand;
+							BattleUnit::WeaponStatus status =
+							    BattleUnit::WeaponStatus::FiringBothHands;
+							switch (selectionState)
+							{
+								case BattleSelectionState::FireLeft:
+									status = BattleUnit::WeaponStatus::FiringLeftHand;
+									break;
+								case BattleSelectionState::FireRight:
+									status = BattleUnit::WeaponStatus::FiringRightHand;
+									break;
+							}
+							// If non-player unit under cursor - fire at unit, otherwise fire at
+							// tile
+							if (unitOccupying &&
+							    unitOccupying->owner != state->current_battle->currentPlayer)
+							{
+								orderFire({&*state, unitOccupying->id}, status);
+							}
+							else
+							{
+								bool modified = (modifierLAlt || modifierRAlt);
+								orderFire(t, status, modified);
+							}
 							break;
-						case BattleSelectionState::FireRight:
-							status = BattleUnit::WeaponStatus::FiringRightHand;
+						}
+						case Event::MouseButton::Right:
+						{
+							if (selectionState != BattleSelectionState::FireAny)
+							{
+								selectionState = BattleSelectionState::Normal;
+							}
 							break;
 						}
-						// If non-player unit under cursor - fire at unit, otherwise fire at tile
-						if (unitOccupying && unitOccupying->owner != state->current_battle->currentPlayer)
-						{
-							orderFire({ &*state, unitOccupying->id }, status);
-						}
-						else
-						{
-							bool modified = (modifierLAlt || modifierRAlt);
-							orderFire(t, status, modified);
-						}
-						break;
-					}
-					case Event::MouseButton::Right:
-					{
-						if (selectionState != BattleSelectionState::FireAny)
-						{
-							selectionState = BattleSelectionState::Normal;
-						}
-						break;
-					}
 					}
 					break;
 				case BattleSelectionState::ThrowRight:
@@ -1598,17 +1620,17 @@ void BattleView::eventOccurred(Event *e)
 				case BattleSelectionState::TeleportRight:
 					switch (buttonPressed)
 					{
-					case Event::MouseButton::Left:
-					{
-						bool right = selectionState == BattleSelectionState::TeleportRight;
-						orderTeleport(t, right);
-						break;
-					}
-					case Event::MouseButton::Right:
-					{
-						selectionState = BattleSelectionState::Normal;
-						break;
-					}
+						case Event::MouseButton::Left:
+						{
+							bool right = selectionState == BattleSelectionState::TeleportRight;
+							orderTeleport(t, right);
+							break;
+						}
+						case Event::MouseButton::Right:
+						{
+							selectionState = BattleSelectionState::Normal;
+							break;
+						}
 					}
 					break;
 			}
@@ -1683,8 +1705,10 @@ void BattleView::onNewTurn()
 	if (state->current_battle->currentActiveOrganisation == state->current_battle->currentPlayer)
 	{
 		baseForm->findControlTyped<Ticker>("NEWS_TICKER")
-			->addMessage(tr("Turn:") +" "+UString::format("%d", state->current_battle->currentTurn)
-			+ "   "+ tr("Side:") +"  " +tr(state->current_battle->currentActiveOrganisation->name));
+		    ->addMessage(tr("Turn:") + " " +
+		                 UString::format("%d", state->current_battle->currentTurn) + "   " +
+		                 tr("Side:") + "  " +
+		                 tr(state->current_battle->currentActiveOrganisation->name));
 	}
 }
 
@@ -1784,10 +1808,7 @@ void BattleView::updateItemInfo(bool right)
 	this->activeTab->findControlTyped<Graphic>("OVERLAY_" + name + "_HAND")->setImage(overlay);
 }
 
-void BattleView::finish()
-{
-	fw().getCursor().CurrentType = ApocCursor::CursorType::Normal;
-}
+void BattleView::finish() { fw().getCursor().CurrentType = ApocCursor::CursorType::Normal; }
 
 AgentEquipmentInfo BattleView::createItemOverlayInfo(bool rightHand)
 {
@@ -1838,6 +1859,5 @@ bool AgentEquipmentInfo::operator==(const AgentEquipmentInfo &other) const
 	return (this->accuracy / 2 == other.accuracy / 2 && this->curAmmo == other.curAmmo &&
 	        this->itemType == other.itemType && this->damageType == other.damageType);
 }
-
 
 }; // namespace OpenApoc

--- a/game/ui/battle/battleview.h
+++ b/game/ui/battle/battleview.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "game/state/battle/battleunit.h"
 #include "game/ui/tileview/battletileview.h"
 #include "library/colour.h"
 #include "library/sp.h"
@@ -54,12 +55,12 @@ class AgentEquipmentInfo
 
 class BattleView : public BattleTileView
 {
-  private:
+private:
 	const std::vector<Colour> accuracyColors = {
-	    {190, 36, 36},  {203, 28, 2},    {235, 77, 4},    {239, 125, 52},
-	    {243, 170, 85}, {247, 219, 117}, {235, 247, 138},
+		{190, 36, 36},  {203, 28, 2},    {235, 77, 4},    {239, 125, 52},
+		{243, 170, 85}, {247, 219, 117}, {235, 247, 138},
 	};
-	const Colour ammoColour = {158, 24, 12};
+	const Colour ammoColour = { 158, 24, 12 };
 
 	sp<Form> activeTab, baseForm;
 	std::vector<sp<Form>> uiTabsRT;
@@ -72,7 +73,7 @@ class BattleView : public BattleTileView
 	AgentEquipmentInfo leftHandInfo;
 	AgentEquipmentInfo rightHandInfo;
 
-	bool followAgent = false; 
+	bool followAgent = false;
 
 	bool colorForward = true;
 	int colorCurrent = 0;
@@ -105,13 +106,17 @@ class BattleView : public BattleTileView
 	void onNewTurn();
 
 	// Unit orers
-	// Move, offset 1 means strafing, 2 means move backwards
+
 	void orderMove(Vec3<int> target, bool strafe = false, bool demandGiveWay = false);
 	void orderTurn(Vec3<int> target);
 	void orderDrop(bool right);
 	void orderThrow(Vec3<int> target, bool right);
 	void orderTeleport(Vec3<int> target, bool right);
 	void orderSelect(sp<BattleUnit> u, bool inverse = false, bool additive = false);
+	void orderFire(Vec3<int> target, BattleUnit::WeaponStatus status = BattleUnit::WeaponStatus::FiringBothHands, bool modifier = false);
+	void orderFire(StateRef<BattleUnit> u, BattleUnit::WeaponStatus status = BattleUnit::WeaponStatus::FiringBothHands);
+	void orderFocus(StateRef<BattleUnit> u);
+
 	void attemptToClearCurrentOrders(sp<BattleUnit> u, bool overrideBodyStateChange = false);
 	bool canEmplaceTurnInFront(sp<BattleUnit> u);
 

--- a/game/ui/battle/battleview.h
+++ b/game/ui/battle/battleview.h
@@ -30,7 +30,7 @@ enum class BattleSelectionState
 	NormalCtrlAlt,
 	PsiLeft,
 	PsiRight,
-	FireAny, 
+	FireAny,
 	FireLeft,
 	FireRight,
 	ThrowLeft,
@@ -55,12 +55,12 @@ class AgentEquipmentInfo
 
 class BattleView : public BattleTileView
 {
-private:
+  private:
 	const std::vector<Colour> accuracyColors = {
-		{190, 36, 36},  {203, 28, 2},    {235, 77, 4},    {239, 125, 52},
-		{243, 170, 85}, {247, 219, 117}, {235, 247, 138},
+	    {190, 36, 36},  {203, 28, 2},    {235, 77, 4},    {239, 125, 52},
+	    {243, 170, 85}, {247, 219, 117}, {235, 247, 138},
 	};
-	const Colour ammoColour = { 158, 24, 12 };
+	const Colour ammoColour = {158, 24, 12};
 
 	sp<Form> activeTab, baseForm;
 	std::vector<sp<Form>> uiTabsRT;
@@ -113,8 +113,11 @@ private:
 	void orderThrow(Vec3<int> target, bool right);
 	void orderTeleport(Vec3<int> target, bool right);
 	void orderSelect(sp<BattleUnit> u, bool inverse = false, bool additive = false);
-	void orderFire(Vec3<int> target, BattleUnit::WeaponStatus status = BattleUnit::WeaponStatus::FiringBothHands, bool modifier = false);
-	void orderFire(StateRef<BattleUnit> u, BattleUnit::WeaponStatus status = BattleUnit::WeaponStatus::FiringBothHands);
+	void orderFire(Vec3<int> target,
+	               BattleUnit::WeaponStatus status = BattleUnit::WeaponStatus::FiringBothHands,
+	               bool modifier = false);
+	void orderFire(StateRef<BattleUnit> u,
+	               BattleUnit::WeaponStatus status = BattleUnit::WeaponStatus::FiringBothHands);
 	void orderFocus(StateRef<BattleUnit> u);
 
 	void attemptToClearCurrentOrders(sp<BattleUnit> u, bool overrideBodyStateChange = false);

--- a/game/ui/city/baseselectscreen.cpp
+++ b/game/ui/city/baseselectscreen.cpp
@@ -138,7 +138,7 @@ void BaseSelectScreen::render()
 	// If there's a modal dialog, darken the screen
 	if (fw().stageGetCurrent() != this->shared_from_this())
 	{
-		fw().renderer->drawFilledRect({ 0, 0 }, fw().displayGetSize(), Colour{ 0, 0, 0, 128 });
+		fw().renderer->drawFilledRect({0, 0}, fw().displayGetSize(), Colour{0, 0, 0, 128});
 	}
 }
 

--- a/game/ui/general/mapselector.cpp
+++ b/game/ui/general/mapselector.cpp
@@ -45,7 +45,8 @@ std::future<void> loadBattleBuilding(sp<Building> building, sp<GameState> state)
 	auto loadTask = fw().threadPool->enqueue([building, state]() -> void {
 		std::list<StateRef<Agent>> agents;
 		for (auto &a : state->agents)
-			if (a.second->type->role == AgentType::Role::Soldier && a.second->owner == state->getPlayer())
+			if (a.second->type->role == AgentType::Role::Soldier &&
+			    a.second->owner == state->getPlayer())
 				agents.emplace_back(state.get(), a.second);
 
 		StateRef<Organisation> org = building->owner;
@@ -101,7 +102,8 @@ std::future<void> loadBattleVehicle(sp<VehicleType> vehicle, sp<GameState> state
 	auto loadTask = fw().threadPool->enqueue([vehicle, state]() -> void {
 		std::list<StateRef<Agent>> agents;
 		for (auto &a : state->agents)
-			if (a.second->type->role == AgentType::Role::Soldier && a.second->owner == state->getPlayer())
+			if (a.second->type->role == AgentType::Role::Soldier &&
+			    a.second->owner == state->getPlayer())
 				agents.emplace_back(state.get(), a.second);
 
 		StateRef<Organisation> org = {state.get(), UString("ORG_ALIEN")};

--- a/game/ui/tileview/battletileview.cpp
+++ b/game/ui/tileview/battletileview.cpp
@@ -1,4 +1,3 @@
-#include "game/state/organisation.h"
 #include "game/ui/tileview/battletileview.h"
 #include "forms/ui.h"
 #include "framework/event.h"
@@ -6,8 +5,9 @@
 #include "framework/includes.h"
 #include "game/state/battle/battle.h"
 #include "game/state/battle/battleunitmission.h"
-#include "game/state/tileview/tileobject_battleunit.h"
+#include "game/state/organisation.h"
 #include "game/state/tileview/tileobject_battleitem.h"
+#include "game/state/tileview/tileobject_battleunit.h"
 
 namespace OpenApoc
 {
@@ -15,7 +15,7 @@ BattleTileView::BattleTileView(TileMap &map, Vec3<int> isoTileSize, Vec2<int> st
                                TileViewMode initialMode, int currentZLevel,
                                Vec3<float> screenCenterTile, sp<Battle> battle)
     : TileView(map, isoTileSize, stratTileSize, initialMode), currentZLevel(currentZLevel),
-	battle(battle)
+      battle(battle)
 {
 	layerDrawingMode = LayerDrawingMode::UpToCurrentLevel;
 	selectedTileEmptyImageBack =
@@ -145,9 +145,9 @@ BattleTileView::BattleTileView(TileMap &map, Vec3<int> isoTileSize, Vec2<int> st
 
 	auto font = ui().getFont("SMALLSET");
 
-	for (int i = 0;i <= 99; i++)
+	for (int i = 0; i <= 99; i++)
 	{
-		tuIndicators.push_back(font->getString(UString::format("%d",i)));
+		tuIndicators.push_back(font->getString(UString::format("%d", i)));
 	}
 	pathPreviewTooFar = font->getString(tr("Too Far"));
 	pathPreviewUnreachable = font->getString(tr("Blocked"));
@@ -209,7 +209,8 @@ void BattleTileView::render()
 		iconAnimationTicksAccumulated++;
 		iconAnimationTicksAccumulated %= targetLocationIcons.size() * TARGET_ICONS_ANIMATION_DELAY;
 		focusAnimationTicksAccumulated++;
-		focusAnimationTicksAccumulated %= (2 * FOCUS_ICONS_ANIMATION_FRAMES - 2) * FOCUS_ICONS_ANIMATION_DELAY;
+		focusAnimationTicksAccumulated %=
+		    (2 * FOCUS_ICONS_ANIMATION_FRAMES - 2) * FOCUS_ICONS_ANIMATION_DELAY;
 	}
 
 	// screenOffset.x/screenOffset.y is the 'amount added to the tile coords' - so we want
@@ -395,7 +396,8 @@ void BattleTileView::render()
 						if (u)
 						{
 							// FIXME: Check if player can see unit, if not - do not change cursor!
-							if (battle->currentPlayer->isRelatedTo(u->getUnit()->owner) == Organisation::Relation::Hostile)
+							if (battle->currentPlayer->isRelatedTo(u->getUnit()->owner) ==
+							    Organisation::Relation::Hostile)
 							{
 								selectionImageBack = selectedTileFireImageBack;
 								selectionImageFront = selectedTileFireImageFront;
@@ -453,7 +455,7 @@ void BattleTileView::render()
 									    waypointLocations.end())
 									{
 										r.draw(waypointImageSource[iconAnimationTicksAccumulated /
-										                     TARGET_ICONS_ANIMATION_DELAY],
+										                           TARGET_ICONS_ANIMATION_DELAY],
 										       tileToOffsetScreenCoords(Vec3<float>{
 										           x, y, tile->getRestingPosition().z}) -
 										           targetLocationOffset);
@@ -471,25 +473,27 @@ void BattleTileView::render()
 									if (!selectedUnits.empty())
 									{
 										auto u = std::static_pointer_cast<TileObjectBattleUnit>(obj)
-											->getUnit();
-										auto selectedPos =
-											std::find(selectedUnits.begin(), selectedUnits.end(), u);
+										             ->getUnit();
+										auto selectedPos = std::find(selectedUnits.begin(),
+										                             selectedUnits.end(), u);
 
 										if (selectedPos == selectedUnits.begin())
 										{
-											unitsToDrawSelectionArrows.push_back({ u, true });
+											unitsToDrawSelectionArrows.push_back({u, true});
 										}
 										else if (selectedPos != selectedUnits.end())
 										{
-											unitsToDrawSelectionArrows.push_back({ u, false });
+											unitsToDrawSelectionArrows.push_back({u, false});
 										}
 										// If visible and focused - draw focus arrows
-										if (true)// FIXME: Check if visible by current player
+										if (true) // FIXME: Check if visible by current player
 										{
 											bool focusedBySelectedUnits = false;
 											for (auto su : selectedUnits)
 											{
-												if (std::find(u->focusedByUnits.begin(), u->focusedByUnits.end(), su) != u->focusedByUnits.end())
+												if (std::find(u->focusedByUnits.begin(),
+												              u->focusedByUnits.end(),
+												              su) != u->focusedByUnits.end())
 												{
 													focusedBySelectedUnits = true;
 													break;
@@ -497,7 +501,8 @@ void BattleTileView::render()
 											}
 											if (focusedBySelectedUnits)
 											{
-												unitsToDrawFocusArrows.push_back({ obj, u->isLarge() });
+												unitsToDrawFocusArrows.push_back(
+												    {obj, u->isLarge()});
 											}
 										}
 									}
@@ -510,7 +515,7 @@ void BattleTileView::render()
 							// When done with all objects, draw the front selection image
 							if (tile == selTileOnCurLevel && layer == 0)
 							{
-								static const Vec2<int> offset = { 2, -53 };
+								static const Vec2<int> offset = {2, -53};
 
 								r.draw(selectionImageFront,
 								       tileToOffsetScreenCoords(selTilePosOnCurLevel) -
@@ -519,19 +524,20 @@ void BattleTileView::render()
 								{
 									sp<Image> img;
 									switch (previewedPathCost)
-									{ 
-									case -3:
-										img = pathPreviewUnreachable;
-										break;
-									case -2:
-										img = pathPreviewTooFar;
-										break;
-									default:
-										img = tuIndicators[previewedPathCost];
-										break;
+									{
+										case -3:
+											img = pathPreviewUnreachable;
+											break;
+										case -2:
+											img = pathPreviewTooFar;
+											break;
+										default:
+											img = tuIndicators[previewedPathCost];
+											break;
 									}
-									r.draw(img, tileToOffsetScreenCoords(selTilePosOnCurLevel)
-										+ offset - Vec2<int>{img->size.x / 2, img->size.y / 2});
+									r.draw(img, tileToOffsetScreenCoords(selTilePosOnCurLevel) +
+									                offset -
+									                Vec2<int>{img->size.x / 2, img->size.y / 2});
 								}
 							}
 #ifdef PATHFINDING_DEBUG
@@ -572,31 +578,34 @@ void BattleTileView::render()
 								}
 								auto &obj = tile->drawnObjects[layer][obj_id];
 								bool draw = false;
-								if ((obj->getType() == TileObject::Type::Unit && obj->getPosition().z < zTo) )
+								if ((obj->getType() == TileObject::Type::Unit &&
+								     obj->getPosition().z < zTo))
 								{
 									draw = true;
 									if (!selectedUnits.empty())
 									{
 										auto u = std::static_pointer_cast<TileObjectBattleUnit>(obj)
-											->getUnit();
-										auto selectedPos =
-											std::find(selectedUnits.begin(), selectedUnits.end(), u);
+										             ->getUnit();
+										auto selectedPos = std::find(selectedUnits.begin(),
+										                             selectedUnits.end(), u);
 
 										if (selectedPos == selectedUnits.begin())
 										{
-											unitsToDrawSelectionArrows.push_back({ u, true });
+											unitsToDrawSelectionArrows.push_back({u, true});
 										}
 										else if (selectedPos != selectedUnits.end())
 										{
-											unitsToDrawSelectionArrows.push_back({ u, false });
+											unitsToDrawSelectionArrows.push_back({u, false});
 										}
 										// If visible and focused - draw focus arrows
-										if (true)// FIXME: Check if visible by current player
+										if (true) // FIXME: Check if visible by current player
 										{
 											bool focusedBySelectedUnits = false;
 											for (auto su : selectedUnits)
 											{
-												if (std::find(u->focusedByUnits.begin(), u->focusedByUnits.end(), su) != u->focusedByUnits.end())
+												if (std::find(u->focusedByUnits.begin(),
+												              u->focusedByUnits.end(),
+												              su) != u->focusedByUnits.end())
 												{
 													focusedBySelectedUnits = true;
 													break;
@@ -604,7 +613,8 @@ void BattleTileView::render()
 											}
 											if (focusedBySelectedUnits)
 											{
-												unitsToDrawFocusArrows.push_back({ obj, u->isLarge() });
+												unitsToDrawFocusArrows.push_back(
+												    {obj, u->isLarge()});
 											}
 										}
 									}
@@ -612,7 +622,8 @@ void BattleTileView::render()
 								if (obj->getType() == TileObject::Type::Item)
 								{
 									draw = !std::static_pointer_cast<TileObjectBattleItem>(obj)
-										->getItem()->supported;
+									            ->getItem()
+									            ->supported;
 								}
 								if (draw)
 								{
@@ -634,20 +645,20 @@ void BattleTileView::render()
 				static const Vec2<float> offsetRunning = {0.0f, 0.0f};
 				static const Vec2<float> offsetBehavior = {0.0f, 0.0f};
 				static const Vec2<float> offsetBleed = {-5.0f, 0.0f};
-				static const Vec2<float> offsetTU = { 13.0f, -5.0f };
+				static const Vec2<float> offsetTU = {13.0f, -5.0f};
 
 				Vec2<float> pos =
-					tileToOffsetScreenCoords(
-					    obj.first->getPosition() +
-					    Vec3<float>{0.0f, 0.0f, obj.first->getCurrentHeight() * 1.5f / 40.0f}) +
-					offset;
+				    tileToOffsetScreenCoords(
+				        obj.first->getPosition() +
+				        Vec3<float>{0.0f, 0.0f, obj.first->getCurrentHeight() * 1.5f / 40.0f}) +
+				    offset;
 
 				// FIXME: Draw hit points
 				r.draw(obj.second ? activeUnitSelectionArrow[obj.first->squadNumber]
-					                : inactiveUnitSelectionArrow[obj.first->squadNumber],
-					    pos);
+				                  : inactiveUnitSelectionArrow[obj.first->squadNumber],
+				       pos);
 				r.draw(behaviorUnitSelectionUnderlay[obj.first->behavior_mode],
-					    pos + offsetBehavior);
+				       pos + offsetBehavior);
 
 				if (battle->mode == Battle::Mode::TurnBased)
 				{
@@ -671,34 +682,40 @@ void BattleTileView::render()
 					}
 				}
 			}
-			
+
 			// Draw unit focus arrows
 			if (!unitsToDrawFocusArrows.empty())
 			{
-				static const Vec2<float> offset1 = { -20.0f, -29.0f };
-				static const Vec2<float> offset2 = {  22.0f, -29.0f };
-				static const Vec2<float> offset3 = { -20.0f,  27.0f };
-				static const Vec2<float> offset4 = {  22.0f,  27.0f };
-				static const Vec2<float> offsetd14 = {-1.0f,  -1.0f };
-				static const Vec2<float> offsetd23 = { 1.0f,  -1.0f };
-				
+				static const Vec2<float> offset1 = {-20.0f, -29.0f};
+				static const Vec2<float> offset2 = {22.0f, -29.0f};
+				static const Vec2<float> offset3 = {-20.0f, 27.0f};
+				static const Vec2<float> offset4 = {22.0f, 27.0f};
+				static const Vec2<float> offsetd14 = {-1.0f, -1.0f};
+				static const Vec2<float> offsetd23 = {1.0f, -1.0f};
+
 				float offset = focusAnimationTicksAccumulated / FOCUS_ICONS_ANIMATION_DELAY;
 				// Offset goes like this: 0 1 2 3 4 3 2 1  (example for 5 frames)
 				// Therefore, if value is >=frames, we do 2*frames -2 -offset
 				// For example, 2*5 - 2 - 5 = 3, that's how we get 3 that's after 4
-				Vec2<float> imgOffset = { (float)battle->common_image_list->focusArrows[0]->size.x/2.0f, (float)battle->common_image_list->focusArrows[0]->size.y / 2.0f };
+				Vec2<float> imgOffset = {
+				    (float)battle->common_image_list->focusArrows[0]->size.x / 2.0f,
+				    (float)battle->common_image_list->focusArrows[0]->size.y / 2.0f};
 				if (offset >= FOCUS_ICONS_ANIMATION_FRAMES)
 					offset = 2 * FOCUS_ICONS_ANIMATION_FRAMES - 2 - offset;
-				
+
 				for (auto &obj : unitsToDrawFocusArrows)
 				{
 					float largeOffset = obj.second ? 2.0f : 1.0f;
 					Vec2<float> pos = tileToOffsetScreenCoords(obj.first->getCenter());
 
-					r.draw(battle->common_image_list->focusArrows[0], pos - imgOffset + largeOffset * offset1 + offset * offsetd14);
-					r.draw(battle->common_image_list->focusArrows[1], pos - imgOffset + largeOffset * offset2 + offset *offsetd23);
-					r.draw(battle->common_image_list->focusArrows[2], pos - imgOffset + largeOffset * offset3 - offset *offsetd23);
-					r.draw(battle->common_image_list->focusArrows[3], pos - imgOffset + largeOffset * offset4 - offset *offsetd14);
+					r.draw(battle->common_image_list->focusArrows[0],
+					       pos - imgOffset + largeOffset * offset1 + offset * offsetd14);
+					r.draw(battle->common_image_list->focusArrows[1],
+					       pos - imgOffset + largeOffset * offset2 + offset * offsetd23);
+					r.draw(battle->common_image_list->focusArrows[2],
+					       pos - imgOffset + largeOffset * offset3 - offset * offsetd23);
+					r.draw(battle->common_image_list->focusArrows[3],
+					       pos - imgOffset + largeOffset * offset4 - offset * offsetd14);
 				}
 			}
 		}
@@ -855,7 +872,7 @@ void BattleTileView::resetPathPreview()
 	{
 		pathPreviewTicksAccumulated = 0;
 		previewedPathCost = -1;
-		lastSelectedUnitPosition = { -1,-1,-1 };
+		lastSelectedUnitPosition = {-1, -1, -1};
 		pathPreview.clear();
 	}
 }
@@ -872,11 +889,12 @@ void BattleTileView::updatePathPreview()
 		return;
 	auto &map = lastSelectedUnit->tileObject->map;
 	auto to = map.getTile(target);
-	
+
 	// Standart check for passability
 	while (true)
 	{
-		if (!to->getPassable(lastSelectedUnit->isLarge(), lastSelectedUnit->agent->type->bodyType->maxHeight))
+		if (!to->getPassable(lastSelectedUnit->isLarge(),
+		                     lastSelectedUnit->agent->type->bodyType->maxHeight))
 		{
 			previewedPathCost = -3;
 			return;
@@ -889,17 +907,18 @@ void BattleTileView::updatePathPreview()
 		if (target.z == -1)
 		{
 			LogError("Solid ground missing on level 0? Reached %d %d %d", target.x, target.y,
-				target.z);
+			         target.z);
 			return;
 		}
 		to = map.getTile(target);
 	}
 
-	// Cost to move is 1.5x if prone and 0.5x if running, to keep things in integer 
+	// Cost to move is 1.5x if prone and 0.5x if running, to keep things in integer
 	// we use a value that is then divided by 2
 	float cost = 0.0f;
 	int cost_multiplier_x_2 = 2;
-	if (lastSelectedUnit->agent->canRun() && lastSelectedUnit->movement_mode == BattleUnit::MovementMode::Running)
+	if (lastSelectedUnit->agent->canRun() &&
+	    lastSelectedUnit->movement_mode == BattleUnit::MovementMode::Running)
 	{
 		cost_multiplier_x_2 = 1;
 	}
@@ -907,12 +926,13 @@ void BattleTileView::updatePathPreview()
 	{
 		cost_multiplier_x_2 = 3;
 	}
-	
+
 	// Get path
-	float maxCost = (float)lastSelectedUnit->agent->modified_stats.time_units * 2 / cost_multiplier_x_2;
-	pathPreview = map.findShortestPath(lastSelectedUnit->goalPosition,
-		target, 1000, BattleUnitTileHelper{ map,
-		*lastSelectedUnit }, false, &cost, maxCost);
+	float maxCost =
+	    (float)lastSelectedUnit->agent->modified_stats.time_units * 2 / cost_multiplier_x_2;
+	pathPreview =
+	    map.findShortestPath(lastSelectedUnit->goalPosition, target, 1000,
+	                         BattleUnitTileHelper{map, *lastSelectedUnit}, false, &cost, maxCost);
 	if (pathPreview.empty())
 	{
 		LogError("Empty path returned for path preview!?");
@@ -941,5 +961,4 @@ void BattleTileView::updatePathPreview()
 		pathPreview.pop_front();
 	}
 }
-
 }

--- a/game/ui/tileview/battletileview.h
+++ b/game/ui/tileview/battletileview.h
@@ -13,6 +13,12 @@ class BattleTileView : public TileView
 	// Formula: FPS / DESIRED_ANIMATIONS_PER_SECOND
 	static const int TARGET_ICONS_ANIMATION_DELAY = 60 / 4;
 
+	// Total amount of different focus icon states
+	static const int FOCUS_ICONS_ANIMATION_FRAMES = 4;
+
+	// Forrmula: FPS / FOCUS_ICONS_ANIMATION_FRAMES(both ways) / DESIRED_ANIMATIONS_PER_SECOND
+	static const int FOCUS_ICONS_ANIMATION_DELAY = 60 / (2 * FOCUS_ICONS_ANIMATION_FRAMES - 2) / 2;
+
   public:
 	enum class LayerDrawingMode
 	{
@@ -50,8 +56,8 @@ class BattleTileView : public TileView
 	std::vector<sp<Image>> waypointIcons;
 	std::vector<sp<Image>> waypointDarkIcons;
 	int iconAnimationTicksAccumulated = 0;
+	int focusAnimationTicksAccumulated = 0;
 
-	
   public:
 	BattleTileView(TileMap &map, Vec3<int> isoTileSize, Vec2<int> stratTileSize,
 	               TileViewMode initialMode, int currentZLevel, Vec3<float> screenCenterTile, sp<Battle> battle);

--- a/game/ui/tileview/battletileview.h
+++ b/game/ui/tileview/battletileview.h
@@ -60,12 +60,14 @@ class BattleTileView : public TileView
 
   public:
 	BattleTileView(TileMap &map, Vec3<int> isoTileSize, Vec2<int> stratTileSize,
-	               TileViewMode initialMode, int currentZLevel, Vec3<float> screenCenterTile, sp<Battle> battle);
+	               TileViewMode initialMode, int currentZLevel, Vec3<float> screenCenterTile,
+	               sp<Battle> battle);
 	~BattleTileView() override;
 
 	std::list<sp<BattleUnit>> selectedUnits;
 
-	// In turn-based, preview path cost when hovering over same tile for more than set amount of time
+	// In turn-based, preview path cost when hovering over same tile for more than set amount of
+	// time
 	sp<BattleUnit> lastSelectedUnit;
 	Vec3<int> lastSelectedUnitPosition;
 	sp<Image> pathPreviewTooFar;

--- a/game/ui/tileview/tileview.cpp
+++ b/game/ui/tileview/tileview.cpp
@@ -273,8 +273,5 @@ void TileView::renderStrategyOverlay(Renderer &r)
 	}
 }
 
-void TileView::update()
-{
-	applyScrolling();
-}
+void TileView::update() { applyScrolling(); }
 }; // namespace OpenApoc

--- a/tools/extractors/extract_agent_equipment.cpp
+++ b/tools/extractors/extract_agent_equipment.cpp
@@ -7,30 +7,30 @@
 #include "tools/extractors/extractors.h"
 #include <limits>
 
-#define E_TRONLAUN 37	 //extra / tronlaun
-#define A_QUEENWHP 97	 //tactical / aliens / attacks / queenwhp
-#define A_SPITTER 98	 //tactical / aliens / attacks / spitter
-#define A_WORMSPIT 99	 //tactical / aliens / attacks / wormspit
-#define A_WRMATTAK  100	 //tactical / aliens / attacks / wrmattak
-#define W_BULLET1 161	 //bullet1
-#define W_BULLET2 162	 //bullet2
-#define W_BULLET3 163	 //bullet3
-#define W_DCANNON1 164	 //dcannon1
-#define W_DIMNMISL 165	 //dimnmisl
-#define W_DISRUPTR 166	 //disruptr
-#define W_ENTROPY 168	 //entropy
-#define W_MARSEC1 169	 //marsec1
-#define W_MARSEC2 170	 //marsec2
-#define W_MEGAPOL 171	 //megapol
-#define W_MEGASTUN 172	 //megastun
-#define W_MEGCANON 173	 //megcanon
-#define W_MEGHIT 174	 //meghit
-#define W_POWERS 175	 //powers
-#define W_SNIPER 177	 //sniper
-#define W_TOXIGUN 181	 //toxigun
-#define W_TRAKGUN 182	 //trakgun
-#define W_TRAKHIT 183	 //trakgun
-#define W_ZAPHIT 184	 //zaphit
+#define E_TRONLAUN 37  // extra / tronlaun
+#define A_QUEENWHP 97  // tactical / aliens / attacks / queenwhp
+#define A_SPITTER 98   // tactical / aliens / attacks / spitter
+#define A_WORMSPIT 99  // tactical / aliens / attacks / wormspit
+#define A_WRMATTAK 100 // tactical / aliens / attacks / wrmattak
+#define W_BULLET1 161  // bullet1
+#define W_BULLET2 162  // bullet2
+#define W_BULLET3 163  // bullet3
+#define W_DCANNON1 164 // dcannon1
+#define W_DIMNMISL 165 // dimnmisl
+#define W_DISRUPTR 166 // disruptr
+#define W_ENTROPY 168  // entropy
+#define W_MARSEC1 169  // marsec1
+#define W_MARSEC2 170  // marsec2
+#define W_MEGAPOL 171  // megapol
+#define W_MEGASTUN 172 // megastun
+#define W_MEGCANON 173 // megcanon
+#define W_MEGHIT 174   // meghit
+#define W_POWERS 175   // powers
+#define W_SNIPER 177   // sniper
+#define W_TOXIGUN 181  // toxigun
+#define W_TRAKGUN 182  // trakgun
+#define W_TRAKHIT 183  // trakgun
+#define W_ZAPHIT 184   // zaphit
 
 namespace OpenApoc
 {
@@ -418,163 +418,165 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state, Difficul
 			UString sfx_path = "";
 			switch (pdata.fire_sfx)
 			{
-			case E_TRONLAUN:
-				sfx_path = "extra/tronlaun";
-				break;
-			case A_QUEENWHP:
-				sfx_path = "tactical/aliens/attacks/queenwhp";
-				break;
-			case A_SPITTER:
-				sfx_path = "tactical/aliens/attacks/spitter";
-				break;
-			case A_WORMSPIT:
-				sfx_path = "tactical/aliens/attacks/wormspit";
-				break;
-			case A_WRMATTAK:
-				sfx_path = "tactical/aliens/attacks/wrmattak";
-				break;
-			case W_BULLET1:
-				sfx_path = "tactical/weapons/bullet1";
-				break;
-			case W_BULLET2:
-				sfx_path = "tactical/weapons/bullet2";
-				break;
-			case W_BULLET3:
-				sfx_path = "tactical/weapons/bullet3";
-				break;
-			case W_DCANNON1:
-				sfx_path = "tactical/weapons/dcannon1";
-				break;
-			case W_DIMNMISL:
-				sfx_path = "tactical/weapons/dimnmisl";
-				break;
-			case W_DISRUPTR:
-				sfx_path = "tactical/weapons/disruptr";
-				break;
-			case W_ENTROPY:
-				sfx_path = "tactical/weapons/entropy";
-				break;
-			case W_MARSEC1:
-				sfx_path = "tactical/weapons/marsec1";
-				break;
-			case W_MARSEC2:
-				sfx_path = "tactical/weapons/marsec2";
-				break;
-			case W_MEGAPOL:
-				sfx_path = "tactical/weapons/megapol";
-				break;
-			case W_MEGASTUN:
-				sfx_path = "tactical/weapons/megastun";
-				break;
-			case W_MEGCANON:
-				sfx_path = "tactical/weapons/megcanon";
-				break;
-			case W_MEGHIT:
-				sfx_path = "tactical/weapons/meghit";
-				break;
-			case W_POWERS:
-				sfx_path = "tactical/weapons/powers";
-				break;
-			case W_SNIPER:
-				sfx_path = "tactical/weapons/sniper";
-				break;
-			case W_TOXIGUN:
-				sfx_path = "tactical/weapons/toxigun";
-				break;
-			case W_TRAKGUN:
-				sfx_path = "tactical/weapons/trakgun";
-				break;
-			case W_TRAKHIT:
-				sfx_path = "tactical/weapons/trakhit";
-				break;
-			case W_ZAPHIT:
-				sfx_path = "tactical/weapons/zaphit";
-				break;
+				case E_TRONLAUN:
+					sfx_path = "extra/tronlaun";
+					break;
+				case A_QUEENWHP:
+					sfx_path = "tactical/aliens/attacks/queenwhp";
+					break;
+				case A_SPITTER:
+					sfx_path = "tactical/aliens/attacks/spitter";
+					break;
+				case A_WORMSPIT:
+					sfx_path = "tactical/aliens/attacks/wormspit";
+					break;
+				case A_WRMATTAK:
+					sfx_path = "tactical/aliens/attacks/wrmattak";
+					break;
+				case W_BULLET1:
+					sfx_path = "tactical/weapons/bullet1";
+					break;
+				case W_BULLET2:
+					sfx_path = "tactical/weapons/bullet2";
+					break;
+				case W_BULLET3:
+					sfx_path = "tactical/weapons/bullet3";
+					break;
+				case W_DCANNON1:
+					sfx_path = "tactical/weapons/dcannon1";
+					break;
+				case W_DIMNMISL:
+					sfx_path = "tactical/weapons/dimnmisl";
+					break;
+				case W_DISRUPTR:
+					sfx_path = "tactical/weapons/disruptr";
+					break;
+				case W_ENTROPY:
+					sfx_path = "tactical/weapons/entropy";
+					break;
+				case W_MARSEC1:
+					sfx_path = "tactical/weapons/marsec1";
+					break;
+				case W_MARSEC2:
+					sfx_path = "tactical/weapons/marsec2";
+					break;
+				case W_MEGAPOL:
+					sfx_path = "tactical/weapons/megapol";
+					break;
+				case W_MEGASTUN:
+					sfx_path = "tactical/weapons/megastun";
+					break;
+				case W_MEGCANON:
+					sfx_path = "tactical/weapons/megcanon";
+					break;
+				case W_MEGHIT:
+					sfx_path = "tactical/weapons/meghit";
+					break;
+				case W_POWERS:
+					sfx_path = "tactical/weapons/powers";
+					break;
+				case W_SNIPER:
+					sfx_path = "tactical/weapons/sniper";
+					break;
+				case W_TOXIGUN:
+					sfx_path = "tactical/weapons/toxigun";
+					break;
+				case W_TRAKGUN:
+					sfx_path = "tactical/weapons/trakgun";
+					break;
+				case W_TRAKHIT:
+					sfx_path = "tactical/weapons/trakhit";
+					break;
+				case W_ZAPHIT:
+					sfx_path = "tactical/weapons/zaphit";
+					break;
 			}
 			if (sfx_path != "")
 			{
-				e->fire_sfx = fw().data->loadSample("RAWSOUND:xcom3/rawsound/"+sfx_path+".raw:22050");
+				e->fire_sfx =
+				    fw().data->loadSample("RAWSOUND:xcom3/rawsound/" + sfx_path + ".raw:22050");
 			}
 
 			sfx_path = "";
 			switch (pdata.impact_sfx)
 			{
-			case E_TRONLAUN:
-				sfx_path = "extra/tronlaun";
-				break;
-			case A_QUEENWHP:
-				sfx_path = "tactical/aliens/attacks/queenwhp";
-				break;
-			case A_SPITTER:
-				sfx_path = "tactical/aliens/attacks/spitter";
-				break;
-			case A_WORMSPIT:
-				sfx_path = "tactical/aliens/attacks/wormspit";
-				break;
-			case A_WRMATTAK:
-				sfx_path = "tactical/aliens/attacks/wrmattak";
-				break;
-			case W_BULLET1:
-				sfx_path = "tactical/weapons/bullet1";
-				break;
-			case W_BULLET2:
-				sfx_path = "tactical/weapons/bullet2";
-				break;
-			case W_BULLET3:
-				sfx_path = "tactical/weapons/bullet3";
-				break;
-			case W_DCANNON1:
-				sfx_path = "tactical/weapons/dcannon1";
-				break;
-			case W_DIMNMISL:
-				sfx_path = "tactical/weapons/dimnmisl";
-				break;
-			case W_DISRUPTR:
-				sfx_path = "tactical/weapons/disruptr";
-				break;
-			case W_ENTROPY:
-				sfx_path = "tactical/weapons/entropy";
-				break;
-			case W_MARSEC1:
-				sfx_path = "tactical/weapons/marsec1";
-				break;
-			case W_MARSEC2:
-				sfx_path = "tactical/weapons/marsec2";
-				break;
-			case W_MEGAPOL:
-				sfx_path = "tactical/weapons/megapol";
-				break;
-			case W_MEGASTUN:
-				sfx_path = "tactical/weapons/megastun";
-				break;
-			case W_MEGCANON:
-				sfx_path = "tactical/weapons/megcanon";
-				break;
-			case W_MEGHIT:
-				sfx_path = "tactical/weapons/meghit";
-				break;
-			case W_POWERS:
-				sfx_path = "tactical/weapons/powers";
-				break;
-			case W_SNIPER:
-				sfx_path = "tactical/weapons/sniper";
-				break;
-			case W_TOXIGUN:
-				sfx_path = "tactical/weapons/toxigun";
-				break;
-			case W_TRAKGUN:
-				sfx_path = "tactical/weapons/trakgun";
-				break;
-			case W_TRAKHIT:
-				sfx_path = "tactical/weapons/trakhit";
-				break;
-			case W_ZAPHIT:
-				sfx_path = "tactical/weapons/zaphit";
-				break;
+				case E_TRONLAUN:
+					sfx_path = "extra/tronlaun";
+					break;
+				case A_QUEENWHP:
+					sfx_path = "tactical/aliens/attacks/queenwhp";
+					break;
+				case A_SPITTER:
+					sfx_path = "tactical/aliens/attacks/spitter";
+					break;
+				case A_WORMSPIT:
+					sfx_path = "tactical/aliens/attacks/wormspit";
+					break;
+				case A_WRMATTAK:
+					sfx_path = "tactical/aliens/attacks/wrmattak";
+					break;
+				case W_BULLET1:
+					sfx_path = "tactical/weapons/bullet1";
+					break;
+				case W_BULLET2:
+					sfx_path = "tactical/weapons/bullet2";
+					break;
+				case W_BULLET3:
+					sfx_path = "tactical/weapons/bullet3";
+					break;
+				case W_DCANNON1:
+					sfx_path = "tactical/weapons/dcannon1";
+					break;
+				case W_DIMNMISL:
+					sfx_path = "tactical/weapons/dimnmisl";
+					break;
+				case W_DISRUPTR:
+					sfx_path = "tactical/weapons/disruptr";
+					break;
+				case W_ENTROPY:
+					sfx_path = "tactical/weapons/entropy";
+					break;
+				case W_MARSEC1:
+					sfx_path = "tactical/weapons/marsec1";
+					break;
+				case W_MARSEC2:
+					sfx_path = "tactical/weapons/marsec2";
+					break;
+				case W_MEGAPOL:
+					sfx_path = "tactical/weapons/megapol";
+					break;
+				case W_MEGASTUN:
+					sfx_path = "tactical/weapons/megastun";
+					break;
+				case W_MEGCANON:
+					sfx_path = "tactical/weapons/megcanon";
+					break;
+				case W_MEGHIT:
+					sfx_path = "tactical/weapons/meghit";
+					break;
+				case W_POWERS:
+					sfx_path = "tactical/weapons/powers";
+					break;
+				case W_SNIPER:
+					sfx_path = "tactical/weapons/sniper";
+					break;
+				case W_TOXIGUN:
+					sfx_path = "tactical/weapons/toxigun";
+					break;
+				case W_TRAKGUN:
+					sfx_path = "tactical/weapons/trakgun";
+					break;
+				case W_TRAKHIT:
+					sfx_path = "tactical/weapons/trakhit";
+					break;
+				case W_ZAPHIT:
+					sfx_path = "tactical/weapons/zaphit";
+					break;
 			}
 			if (sfx_path != "")
 			{
-				e->impact_sfx = fw().data->loadSample("RAWSOUND:xcom3/rawsound/" + sfx_path + ".raw:22050");
+				e->impact_sfx =
+				    fw().data->loadSample("RAWSOUND:xcom3/rawsound/" + sfx_path + ".raw:22050");
 			}
 
 			e->damage_type = {&state, data_t.getDTypeId(pdata.damage_type)};

--- a/tools/extractors/extract_agent_equipment.cpp
+++ b/tools/extractors/extract_agent_equipment.cpp
@@ -387,6 +387,7 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state, Difficul
 			e->fire_delay = pdata.fire_delay;
 			e->guided = pdata.guided != 0 ? true : false;
 			e->turn_rate = pdata.turn_rate;
+			e->ttl = pdata.ttl;
 			e->range = pdata.range;
 			e->explosion_graphic = pdata.explosion_graphic;
 			if (pdata.fire_sfx != 0xffff)

--- a/tools/extractors/extract_agent_equipment.cpp
+++ b/tools/extractors/extract_agent_equipment.cpp
@@ -7,6 +7,31 @@
 #include "tools/extractors/extractors.h"
 #include <limits>
 
+#define E_TRONLAUN 37	 //extra / tronlaun
+#define A_QUEENWHP 97	 //tactical / aliens / attacks / queenwhp
+#define A_SPITTER 98	 //tactical / aliens / attacks / spitter
+#define A_WORMSPIT 99	 //tactical / aliens / attacks / wormspit
+#define A_WRMATTAK  100	 //tactical / aliens / attacks / wrmattak
+#define W_BULLET1 161	 //bullet1
+#define W_BULLET2 162	 //bullet2
+#define W_BULLET3 163	 //bullet3
+#define W_DCANNON1 164	 //dcannon1
+#define W_DIMNMISL 165	 //dimnmisl
+#define W_DISRUPTR 166	 //disruptr
+#define W_ENTROPY 168	 //entropy
+#define W_MARSEC1 169	 //marsec1
+#define W_MARSEC2 170	 //marsec2
+#define W_MEGAPOL 171	 //megapol
+#define W_MEGASTUN 172	 //megastun
+#define W_MEGCANON 173	 //megcanon
+#define W_MEGHIT 174	 //meghit
+#define W_POWERS 175	 //powers
+#define W_SNIPER 177	 //sniper
+#define W_TOXIGUN 181	 //toxigun
+#define W_TRAKGUN 182	 //trakgun
+#define W_TRAKHIT 183	 //trakgun
+#define W_ZAPHIT 184	 //zaphit
+
 namespace OpenApoc
 {
 
@@ -390,12 +415,167 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state, Difficul
 			e->ttl = pdata.ttl;
 			e->range = pdata.range;
 			e->explosion_graphic = pdata.explosion_graphic;
-			if (pdata.fire_sfx != 0xffff)
-				e->fire_sfx =
-				    fw().data->loadSample(UString::format("RAWSOUND:%d", (int)pdata.fire_sfx));
-			if (pdata.impact_sfx != 0xffff)
-				e->impact_sfx =
-				    fw().data->loadSample(UString::format("RAWSOUND:%d", (int)pdata.impact_sfx));
+			UString sfx_path = "";
+			switch (pdata.fire_sfx)
+			{
+			case E_TRONLAUN:
+				sfx_path = "extra/tronlaun";
+				break;
+			case A_QUEENWHP:
+				sfx_path = "tactical/aliens/attacks/queenwhp";
+				break;
+			case A_SPITTER:
+				sfx_path = "tactical/aliens/attacks/spitter";
+				break;
+			case A_WORMSPIT:
+				sfx_path = "tactical/aliens/attacks/wormspit";
+				break;
+			case A_WRMATTAK:
+				sfx_path = "tactical/aliens/attacks/wrmattak";
+				break;
+			case W_BULLET1:
+				sfx_path = "tactical/weapons/bullet1";
+				break;
+			case W_BULLET2:
+				sfx_path = "tactical/weapons/bullet2";
+				break;
+			case W_BULLET3:
+				sfx_path = "tactical/weapons/bullet3";
+				break;
+			case W_DCANNON1:
+				sfx_path = "tactical/weapons/dcannon1";
+				break;
+			case W_DIMNMISL:
+				sfx_path = "tactical/weapons/dimnmisl";
+				break;
+			case W_DISRUPTR:
+				sfx_path = "tactical/weapons/disruptr";
+				break;
+			case W_ENTROPY:
+				sfx_path = "tactical/weapons/entropy";
+				break;
+			case W_MARSEC1:
+				sfx_path = "tactical/weapons/marsec1";
+				break;
+			case W_MARSEC2:
+				sfx_path = "tactical/weapons/marsec2";
+				break;
+			case W_MEGAPOL:
+				sfx_path = "tactical/weapons/megapol";
+				break;
+			case W_MEGASTUN:
+				sfx_path = "tactical/weapons/megastun";
+				break;
+			case W_MEGCANON:
+				sfx_path = "tactical/weapons/megcanon";
+				break;
+			case W_MEGHIT:
+				sfx_path = "tactical/weapons/meghit";
+				break;
+			case W_POWERS:
+				sfx_path = "tactical/weapons/powers";
+				break;
+			case W_SNIPER:
+				sfx_path = "tactical/weapons/sniper";
+				break;
+			case W_TOXIGUN:
+				sfx_path = "tactical/weapons/toxigun";
+				break;
+			case W_TRAKGUN:
+				sfx_path = "tactical/weapons/trakgun";
+				break;
+			case W_TRAKHIT:
+				sfx_path = "tactical/weapons/trakhit";
+				break;
+			case W_ZAPHIT:
+				sfx_path = "tactical/weapons/zaphit";
+				break;
+			}
+			if (sfx_path != "")
+			{
+				e->fire_sfx = fw().data->loadSample("RAWSOUND:xcom3/rawsound/"+sfx_path+".raw:22050");
+			}
+
+			sfx_path = "";
+			switch (pdata.impact_sfx)
+			{
+			case E_TRONLAUN:
+				sfx_path = "extra/tronlaun";
+				break;
+			case A_QUEENWHP:
+				sfx_path = "tactical/aliens/attacks/queenwhp";
+				break;
+			case A_SPITTER:
+				sfx_path = "tactical/aliens/attacks/spitter";
+				break;
+			case A_WORMSPIT:
+				sfx_path = "tactical/aliens/attacks/wormspit";
+				break;
+			case A_WRMATTAK:
+				sfx_path = "tactical/aliens/attacks/wrmattak";
+				break;
+			case W_BULLET1:
+				sfx_path = "tactical/weapons/bullet1";
+				break;
+			case W_BULLET2:
+				sfx_path = "tactical/weapons/bullet2";
+				break;
+			case W_BULLET3:
+				sfx_path = "tactical/weapons/bullet3";
+				break;
+			case W_DCANNON1:
+				sfx_path = "tactical/weapons/dcannon1";
+				break;
+			case W_DIMNMISL:
+				sfx_path = "tactical/weapons/dimnmisl";
+				break;
+			case W_DISRUPTR:
+				sfx_path = "tactical/weapons/disruptr";
+				break;
+			case W_ENTROPY:
+				sfx_path = "tactical/weapons/entropy";
+				break;
+			case W_MARSEC1:
+				sfx_path = "tactical/weapons/marsec1";
+				break;
+			case W_MARSEC2:
+				sfx_path = "tactical/weapons/marsec2";
+				break;
+			case W_MEGAPOL:
+				sfx_path = "tactical/weapons/megapol";
+				break;
+			case W_MEGASTUN:
+				sfx_path = "tactical/weapons/megastun";
+				break;
+			case W_MEGCANON:
+				sfx_path = "tactical/weapons/megcanon";
+				break;
+			case W_MEGHIT:
+				sfx_path = "tactical/weapons/meghit";
+				break;
+			case W_POWERS:
+				sfx_path = "tactical/weapons/powers";
+				break;
+			case W_SNIPER:
+				sfx_path = "tactical/weapons/sniper";
+				break;
+			case W_TOXIGUN:
+				sfx_path = "tactical/weapons/toxigun";
+				break;
+			case W_TRAKGUN:
+				sfx_path = "tactical/weapons/trakgun";
+				break;
+			case W_TRAKHIT:
+				sfx_path = "tactical/weapons/trakhit";
+				break;
+			case W_ZAPHIT:
+				sfx_path = "tactical/weapons/zaphit";
+				break;
+			}
+			if (sfx_path != "")
+			{
+				e->impact_sfx = fw().data->loadSample("RAWSOUND:xcom3/rawsound/" + sfx_path + ".raw:22050");
+			}
 
 			e->damage_type = {&state, data_t.getDTypeId(pdata.damage_type)};
 			switch (pdata.trigger_type)

--- a/tools/extractors/extract_battle_shared_resources.cpp
+++ b/tools/extractors/extract_battle_shared_resources.cpp
@@ -37,14 +37,22 @@ void InitialGameStateExtractor::extractSharedBattleResources(GameState &state)
 	state.battle_common_image_list->loadingImage =
 	    fw().data->loadImage("xcom3/ufodata/enttact.pcx");
 
-	state.battle_common_image_list->focusArrows.push_back(fw().data->loadImage(UString::format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-		"icons.tab:%d:xcom3/tacdata/tactical.pal", 	64)));
-	state.battle_common_image_list->focusArrows.push_back(fw().data->loadImage(UString::format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-		"icons.tab:%d:xcom3/tacdata/tactical.pal", 65)));
-	state.battle_common_image_list->focusArrows.push_back(fw().data->loadImage(UString::format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-		"icons.tab:%d:xcom3/tacdata/tactical.pal", 66)));
-	state.battle_common_image_list->focusArrows.push_back(fw().data->loadImage(UString::format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-		"icons.tab:%d:xcom3/tacdata/tactical.pal", 67)));
+	state.battle_common_image_list->focusArrows.push_back(
+	    fw().data->loadImage(UString::format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
+	                                         "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                         64)));
+	state.battle_common_image_list->focusArrows.push_back(
+	    fw().data->loadImage(UString::format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
+	                                         "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                         65)));
+	state.battle_common_image_list->focusArrows.push_back(
+	    fw().data->loadImage(UString::format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
+	                                         "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                         66)));
+	state.battle_common_image_list->focusArrows.push_back(
+	    fw().data->loadImage(UString::format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
+	                                         "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                         67)));
 
 	// Common Sounds
 

--- a/tools/extractors/extract_battle_shared_resources.cpp
+++ b/tools/extractors/extract_battle_shared_resources.cpp
@@ -37,6 +37,15 @@ void InitialGameStateExtractor::extractSharedBattleResources(GameState &state)
 	state.battle_common_image_list->loadingImage =
 	    fw().data->loadImage("xcom3/ufodata/enttact.pcx");
 
+	state.battle_common_image_list->focusArrows.push_back(fw().data->loadImage(UString::format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
+		"icons.tab:%d:xcom3/tacdata/tactical.pal", 	64)));
+	state.battle_common_image_list->focusArrows.push_back(fw().data->loadImage(UString::format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
+		"icons.tab:%d:xcom3/tacdata/tactical.pal", 65)));
+	state.battle_common_image_list->focusArrows.push_back(fw().data->loadImage(UString::format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
+		"icons.tab:%d:xcom3/tacdata/tactical.pal", 66)));
+	state.battle_common_image_list->focusArrows.push_back(fw().data->loadImage(UString::format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
+		"icons.tab:%d:xcom3/tacdata/tactical.pal", 67)));
+
 	// Common Sounds
 
 	static const int SOUND_METAL = 0x01;

--- a/tools/extractors/extract_unit_animation_pack_unit.cpp
+++ b/tools/extractors/extract_unit_animation_pack_unit.cpp
@@ -12,9 +12,10 @@ namespace OpenApoc
 
 // Parsing animations for "unit/anim" files
 void InitialGameStateExtractor::extractAnimationPackUnit(sp<BattleUnitAnimationPack> p,
-	const std::vector<AnimationDataAD> &dataAD,
-	const std::vector<AnimationDataUA> &dataUA,
-	std::vector<AnimationDataUF> &dataUF, int x, int y)
+                                                         const std::vector<AnimationDataAD> &dataAD,
+                                                         const std::vector<AnimationDataUA> &dataUA,
+                                                         std::vector<AnimationDataUF> &dataUF,
+                                                         int x, int y)
 {
 	// Frames per 100 units
 	static const int pFrames = 300; // Prone
@@ -27,642 +28,646 @@ void InitialGameStateExtractor::extractAnimationPackUnit(sp<BattleUnitAnimationP
 	{
 		// Downed state: 27
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::None]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Downed][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 27, { x, y });
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Downed][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 27, {x, y});
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Downed][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 27, { x, y });
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Downed][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 27, {x, y});
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Downed][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 27, { x, y });
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Downed][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 27, {x, y});
 
 		// Standing static states: 0, 1, 2
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::None]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Standing][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 0, { x, y });
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Standing][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 0, {x, y});
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Standing][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 1, { x, y });
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Standing][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 1, {x, y});
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Standing][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 2, { x, y });
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Standing][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 2, {x, y});
 
 		// Kneeling static states: 3, 4, 5
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::None]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Kneeling][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 3, { x, y });
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Kneeling][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 3, {x, y});
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Kneeling][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 4, { x, y });
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Kneeling][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 4, {x, y});
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Kneeling][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 5, { x, y });
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Kneeling][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 5, {x, y});
 
 		// Prone static states: 6, 7, 8
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::None]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Prone][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 6, { x, y });
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Prone][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 6, {x, y});
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Prone][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 7, { x, y });
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Prone][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 7, {x, y});
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Prone][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 8, { x, y });
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Prone][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 8, {x, y});
 
 		// Standing walking states: 9, 10, 11
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::None]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Normal]
-			[AgentType::BodyState::Standing][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 9, { x, y }, wFrames);
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::Normal]
+		                      [AgentType::BodyState::Standing][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 9, {x, y}, wFrames);
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Normal]
-			[AgentType::BodyState::Standing][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 10, { x, y }, wFrames);
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::Normal]
+		                      [AgentType::BodyState::Standing][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 10, {x, y}, wFrames);
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Normal]
-			[AgentType::BodyState::Standing][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 11, { x, y }, wFrames);
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::Normal]
+		                      [AgentType::BodyState::Standing][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 11, {x, y}, wFrames);
 
 		// Standing strafing states: 12, 13, 14
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::None]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Strafing]
-			[AgentType::BodyState::Standing][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 12, { x, y }, sFrames);
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::Strafing]
+		                      [AgentType::BodyState::Standing][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 12, {x, y}, sFrames);
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Strafing]
-			[AgentType::BodyState::Standing][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 13, { x, y }, sFrames);
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::Strafing]
+		                      [AgentType::BodyState::Standing][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 13, {x, y}, sFrames);
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Strafing]
-			[AgentType::BodyState::Standing][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 14, { x, y }),
-			sFrames;
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::Strafing]
+		                      [AgentType::BodyState::Standing][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 14, {x, y}),
+		                                                           sFrames;
 
 		// Standing running state: 15
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::None]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Running]
-			[AgentType::BodyState::Standing][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 15, { x, y }, rFrames);
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::Running]
+		                      [AgentType::BodyState::Standing][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 15, {x, y}, rFrames);
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Running]
-			[AgentType::BodyState::Standing][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 15, { x, y }, rFrames);
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::Running]
+		                      [AgentType::BodyState::Standing][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 15, {x, y}, rFrames);
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Running]
-			[AgentType::BodyState::Standing][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 15, { x, y }, rFrames);
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::Running]
+		                      [AgentType::BodyState::Standing][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 15, {x, y}, rFrames);
 
 		// Prone moving state: 18
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::None]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Normal]
-			[AgentType::BodyState::Prone][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 18, { x, y }, pFrames);
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::Normal]
+		                      [AgentType::BodyState::Prone][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 18, {x, y}, pFrames);
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Normal]
-			[AgentType::BodyState::Prone][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 18, { x, y }, pFrames);
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::Normal]
+		                      [AgentType::BodyState::Prone][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 18, {x, y}, pFrames);
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Normal]
-			[AgentType::BodyState::Prone][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 18, { x, y }, pFrames);
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::Normal]
+		                      [AgentType::BodyState::Prone][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 18, {x, y}, pFrames);
 
 		// Jumping moving state: 22
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::None]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Normal]
-			[AgentType::BodyState::Jumping][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 22, { x, y }, jFrames);
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::Normal]
+		                      [AgentType::BodyState::Jumping][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 22, {x, y}, jFrames);
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Normal]
-			[AgentType::BodyState::Jumping][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 22, { x, y }, jFrames);
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::Normal]
+		                      [AgentType::BodyState::Jumping][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 22, {x, y}, jFrames);
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Normal]
-			[AgentType::BodyState::Jumping][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 22, { x, y }, jFrames);
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::Normal]
+		                      [AgentType::BodyState::Jumping][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 22, {x, y}, jFrames);
 
 		// Flying standing/moving/running/strafing state: 24, 25, 26
 		// Standing
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::None]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Flying][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 24, { x, y });
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Flying][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 24, {x, y});
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Flying][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 25, { x, y });
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Flying][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 25, {x, y});
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Flying][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 26, { x, y });
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Flying][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 26, {x, y});
 		// "Walking" in the air
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::None]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Normal]
-			[AgentType::BodyState::Flying][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 24, { x, y }, wFrames);
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::Normal]
+		                      [AgentType::BodyState::Flying][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 24, {x, y}, wFrames);
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Normal]
-			[AgentType::BodyState::Flying][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 25, { x, y }, wFrames);
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::Normal]
+		                      [AgentType::BodyState::Flying][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 25, {x, y}, wFrames);
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Normal]
-			[AgentType::BodyState::Flying][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 26, { x, y }, wFrames);
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::Normal]
+		                      [AgentType::BodyState::Flying][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 26, {x, y}, wFrames);
 		// "Running" in the air
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::None]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Running]
-			[AgentType::BodyState::Flying][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 24, { x, y }, rFrames);
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::Running]
+		                      [AgentType::BodyState::Flying][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 24, {x, y}, rFrames);
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Running]
-			[AgentType::BodyState::Flying][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 25, { x, y }, rFrames);
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::Running]
+		                      [AgentType::BodyState::Flying][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 25, {x, y}, rFrames);
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Running]
-			[AgentType::BodyState::Flying][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 26, { x, y }, rFrames);
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::Running]
+		                      [AgentType::BodyState::Flying][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 26, {x, y}, rFrames);
 		// "Strafing" in the air
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::None]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Strafing]
-			[AgentType::BodyState::Flying][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 24, { x, y }, sFrames);
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::Strafing]
+		                      [AgentType::BodyState::Flying][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 24, {x, y}, sFrames);
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Strafing]
-			[AgentType::BodyState::Flying][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 25, { x, y }, sFrames);
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::Strafing]
+		                      [AgentType::BodyState::Flying][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 25, {x, y}, sFrames);
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Strafing]
-			[AgentType::BodyState::Flying][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 26, { x, y }, sFrames);
+		                      [AgentType::HandState::AtEase][AgentType::MovementState::Strafing]
+		                      [AgentType::BodyState::Flying][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 26, {x, y}, sFrames);
 
 		// Standing aiming static animation: 54, 58
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::Aiming][AgentType::MovementState::None]
-			[AgentType::BodyState::Standing][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 54, { x, y });
+		                      [AgentType::HandState::Aiming][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Standing][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 54, {x, y});
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::Aiming][AgentType::MovementState::None]
-			[AgentType::BodyState::Standing][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 58, { x, y });
+		                      [AgentType::HandState::Aiming][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Standing][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 58, {x, y});
 
 		// Kneeling aiming static animation: 62, 66
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::Aiming][AgentType::MovementState::None]
-			[AgentType::BodyState::Kneeling][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 62, { x, y });
+		                      [AgentType::HandState::Aiming][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Kneeling][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 62, {x, y});
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::Aiming][AgentType::MovementState::None]
-			[AgentType::BodyState::Kneeling][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 66, { x, y });
+		                      [AgentType::HandState::Aiming][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Kneeling][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 66, {x, y});
 
 		// Prone aiming static animation: 70, 74
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::Aiming][AgentType::MovementState::None]
-			[AgentType::BodyState::Prone][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 70, { x, y });
+		                      [AgentType::HandState::Aiming][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Prone][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 70, {x, y});
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::Aiming][AgentType::MovementState::None]
-			[AgentType::BodyState::Prone][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 74, { x, y });
+		                      [AgentType::HandState::Aiming][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Prone][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 74, {x, y});
 
 		// Flying aiming static animation: 86, 90
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::Aiming][AgentType::MovementState::None]
-			[AgentType::BodyState::Flying][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 86, { x, y });
+		                      [AgentType::HandState::Aiming][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Flying][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 86, {x, y});
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::Aiming][AgentType::MovementState::None]
-			[AgentType::BodyState::Flying][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 90, { x, y });
+		                      [AgentType::HandState::Aiming][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Flying][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 90, {x, y});
 
 		// Flying aiming moving animation: 86, 90
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::Aiming][AgentType::MovementState::Normal]
-			[AgentType::BodyState::Flying][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 86, { x, y }, wFrames);
+		                      [AgentType::HandState::Aiming][AgentType::MovementState::Normal]
+		                      [AgentType::BodyState::Flying][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 86, {x, y}, wFrames);
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::Aiming][AgentType::MovementState::Normal]
-			[AgentType::BodyState::Flying][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 90, { x, y }, wFrames);
+		                      [AgentType::HandState::Aiming][AgentType::MovementState::Normal]
+		                      [AgentType::BodyState::Flying][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 90, {x, y}, wFrames);
 
 		// Standing aiming moving overlay animation: 78, 82
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::Aiming][AgentType::MovementState::Normal]
-			[AgentType::BodyState::Standing][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 78, { x, y }, true, wFrames);
+		                      [AgentType::HandState::Aiming][AgentType::MovementState::Normal]
+		                      [AgentType::BodyState::Standing][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 78, {x, y}, true, wFrames);
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::Aiming][AgentType::MovementState::Normal]
-			[AgentType::BodyState::Standing][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 82, { x, y }, true, wFrames);
+		                      [AgentType::HandState::Aiming][AgentType::MovementState::Normal]
+		                      [AgentType::BodyState::Standing][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 82, {x, y}, true, wFrames);
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::Aiming][AgentType::MovementState::Strafing]
-			[AgentType::BodyState::Standing][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 78, { x, y }, true, wFrames);
+		                      [AgentType::HandState::Aiming][AgentType::MovementState::Strafing]
+		                      [AgentType::BodyState::Standing][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 78, {x, y}, true, wFrames);
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::Aiming][AgentType::MovementState::Strafing]
-			[AgentType::BodyState::Standing][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 82, { x, y }, true, wFrames);
+		                      [AgentType::HandState::Aiming][AgentType::MovementState::Strafing]
+		                      [AgentType::BodyState::Standing][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 82, {x, y}, true, wFrames);
 
 		// Standing firing static animation: 53, 57
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::Firing][AgentType::MovementState::None]
-			[AgentType::BodyState::Standing][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 53, { x, y });
+		                      [AgentType::HandState::Firing][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Standing][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 53, {x, y});
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::Firing][AgentType::MovementState::None]
-			[AgentType::BodyState::Standing][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 57, { x, y });
+		                      [AgentType::HandState::Firing][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Standing][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 57, {x, y});
 
 		// Kneeling firing static animation: 61, 65
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::Firing][AgentType::MovementState::None]
-			[AgentType::BodyState::Kneeling][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 61, { x, y });
+		                      [AgentType::HandState::Firing][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Kneeling][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 61, {x, y});
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::Firing][AgentType::MovementState::None]
-			[AgentType::BodyState::Kneeling][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 65, { x, y });
+		                      [AgentType::HandState::Firing][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Kneeling][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 65, {x, y});
 
 		// Prone firing static animation: 69, 73
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::Firing][AgentType::MovementState::None]
-			[AgentType::BodyState::Prone][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 69, { x, y });
+		                      [AgentType::HandState::Firing][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Prone][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 69, {x, y});
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::Firing][AgentType::MovementState::None]
-			[AgentType::BodyState::Prone][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 73, { x, y });
+		                      [AgentType::HandState::Firing][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Prone][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 73, {x, y});
 
 		// Flying firing static animation: 85, 89
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::Firing][AgentType::MovementState::None]
-			[AgentType::BodyState::Flying][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 85, { x, y });
+		                      [AgentType::HandState::Firing][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Flying][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 85, {x, y});
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::Firing][AgentType::MovementState::None]
-			[AgentType::BodyState::Flying][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 89, { x, y });
+		                      [AgentType::HandState::Firing][AgentType::MovementState::None]
+		                      [AgentType::BodyState::Flying][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 89, {x, y});
 
 		// Flying firing "walking" animation: 85, 89
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::Firing][AgentType::MovementState::Normal]
-			[AgentType::BodyState::Flying][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 85, { x, y }, wFrames);
+		                      [AgentType::HandState::Firing][AgentType::MovementState::Normal]
+		                      [AgentType::BodyState::Flying][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 85, {x, y}, wFrames);
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::Firing][AgentType::MovementState::Normal]
-			[AgentType::BodyState::Flying][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 89, { x, y }, wFrames);
+		                      [AgentType::HandState::Firing][AgentType::MovementState::Normal]
+		                      [AgentType::BodyState::Flying][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 89, {x, y}, wFrames);
 
 		// Standing firing moving overlay animation: 77, 81
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::Firing][AgentType::MovementState::Normal]
-			[AgentType::BodyState::Standing][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 77, { x, y }, true, wFrames);
+		                      [AgentType::HandState::Firing][AgentType::MovementState::Normal]
+		                      [AgentType::BodyState::Standing][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 77, {x, y}, true, wFrames);
 		p->standart_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::Firing][AgentType::MovementState::Normal]
-			[AgentType::BodyState::Standing][{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 81, { x, y }, true, wFrames);
+		                      [AgentType::HandState::Firing][AgentType::MovementState::Normal]
+		                      [AgentType::BodyState::Standing][{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 81, {x, y}, true, wFrames);
 	}
 
 	// Body state change animations
 	{
 		// Body Standing -> Downned animation: 47
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::None]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Standing][AgentType::BodyState::Downed]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 47, { x, y });
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Standing][AgentType::BodyState::Downed]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 47, {x, y});
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Standing][AgentType::BodyState::Downed]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 47, { x, y });
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Standing][AgentType::BodyState::Downed]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 47, {x, y});
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Standing][AgentType::BodyState::Downed]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 47, { x, y });
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Standing][AgentType::BodyState::Downed]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 47, {x, y});
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::None]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Downed][AgentType::BodyState::Standing]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 47, { x, y }, true);
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Downed][AgentType::BodyState::Standing]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 47, {x, y}, true);
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Downed][AgentType::BodyState::Standing]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 47, { x, y }, true);
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Downed][AgentType::BodyState::Standing]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 47, {x, y}, true);
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Downed][AgentType::BodyState::Standing]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 47, { x, y }, true);
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Downed][AgentType::BodyState::Standing]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 47, {x, y}, true);
 
 		// Body Kneeling -> Downned animation: 49
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::None]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Kneeling][AgentType::BodyState::Downed]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 49, { x, y });
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Kneeling][AgentType::BodyState::Downed]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 49, {x, y});
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Kneeling][AgentType::BodyState::Downed]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 49, { x, y });
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Kneeling][AgentType::BodyState::Downed]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 49, {x, y});
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Kneeling][AgentType::BodyState::Downed]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 49, { x, y });
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Kneeling][AgentType::BodyState::Downed]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 49, {x, y});
 
 		// Body Prone -> Downned animation: 50
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::None]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Prone][AgentType::BodyState::Downed]
-			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 50, { x, y }, gPrOff({ x, y }), { 0, 0 });
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Prone][AgentType::BodyState::Downed]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 50, {x, y}, gPrOff({x, y}), {0, 0});
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Prone][AgentType::BodyState::Downed]
-			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 50, { x, y }, gPrOff({ x, y }), { 0, 0 });
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Prone][AgentType::BodyState::Downed]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 50, {x, y}, gPrOff({x, y}), {0, 0});
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Prone][AgentType::BodyState::Downed]
-			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 50, { x, y }, gPrOff({ x, y }), { 0, 0 });
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Prone][AgentType::BodyState::Downed]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 50, {x, y}, gPrOff({x, y}), {0, 0});
 
 		// Body Flying -> Downned animation: 51
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::None]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Flying][AgentType::BodyState::Downed]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 51, { x, y });
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Flying][AgentType::BodyState::Downed]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 51, {x, y});
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Flying][AgentType::BodyState::Downed]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 51, { x, y });
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Flying][AgentType::BodyState::Downed]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 51, {x, y});
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Flying][AgentType::BodyState::Downed]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 51, { x, y });
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Flying][AgentType::BodyState::Downed]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 51, {x, y});
 
 		// Body Standing -> Jumping animation: 21
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::None]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Normal]
-			[AgentType::BodyState::Standing][AgentType::BodyState::Jumping]
-			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 21, { x, y }, jFrames);
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::Normal]
+		                        [AgentType::BodyState::Standing][AgentType::BodyState::Jumping]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 21, {x, y}, jFrames);
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Normal]
-			[AgentType::BodyState::Standing][AgentType::BodyState::Jumping]
-			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 21, { x, y }, jFrames);
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::Normal]
+		                        [AgentType::BodyState::Standing][AgentType::BodyState::Jumping]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 21, {x, y}, jFrames);
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Normal]
-			[AgentType::BodyState::Standing][AgentType::BodyState::Jumping]
-			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 21, { x, y }, jFrames);
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::Normal]
+		                        [AgentType::BodyState::Standing][AgentType::BodyState::Jumping]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 21, {x, y}, jFrames);
 
 		// Body Jumping -> Standing animation: 23, 28, 29
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::None]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Normal]
-			[AgentType::BodyState::Jumping][AgentType::BodyState::Standing]
-			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 23, { x, y }, jFrames);
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::Normal]
+		                        [AgentType::BodyState::Jumping][AgentType::BodyState::Standing]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 23, {x, y}, jFrames);
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Normal]
-			[AgentType::BodyState::Jumping][AgentType::BodyState::Standing]
-			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 28, { x, y }, jFrames);
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::Normal]
+		                        [AgentType::BodyState::Jumping][AgentType::BodyState::Standing]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 28, {x, y}, jFrames);
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::Normal]
-			[AgentType::BodyState::Jumping][AgentType::BodyState::Standing]
-			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 29, { x, y }, jFrames);
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::Normal]
+		                        [AgentType::BodyState::Jumping][AgentType::BodyState::Standing]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 29, {x, y}, jFrames);
 
 		// Body Standing -> Kneeling animation: 35, 36, 37
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::None]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Standing][AgentType::BodyState::Kneeling]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 35, { x, y });
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Standing][AgentType::BodyState::Kneeling]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 35, {x, y});
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Standing][AgentType::BodyState::Kneeling]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 36, { x, y });
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Standing][AgentType::BodyState::Kneeling]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 36, {x, y});
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Standing][AgentType::BodyState::Kneeling]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 37, { x, y });
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Standing][AgentType::BodyState::Kneeling]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 37, {x, y});
 
 		// Body Kneeling -> Prone animation: 38, 39, 40
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::None]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Kneeling][AgentType::BodyState::Prone]
-			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 38, { x, y }, { 0, 0 }, gPrOff({ x, y }));
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Kneeling][AgentType::BodyState::Prone]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 38, {x, y}, {0, 0}, gPrOff({x, y}));
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Kneeling][AgentType::BodyState::Prone]
-			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 38, { x, y }, { 0, 0 }, gPrOff({ x, y }));
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Kneeling][AgentType::BodyState::Prone]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 38, {x, y}, {0, 0}, gPrOff({x, y}));
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Kneeling][AgentType::BodyState::Prone]
-			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 40, { x, y }, { 0, 0 }, gPrOff({ x, y }));
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Kneeling][AgentType::BodyState::Prone]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 40, {x, y}, {0, 0}, gPrOff({x, y}));
 
 		// Body Prone -> Kneeling animation: 92, 93, 94
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::None]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Prone][AgentType::BodyState::Kneeling]
-			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 92, { x, y }, gPrOff({ x, y }), { 0, 0 });
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Prone][AgentType::BodyState::Kneeling]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 92, {x, y}, gPrOff({x, y}), {0, 0});
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Prone][AgentType::BodyState::Kneeling]
-			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 93, { x, y }, gPrOff({ x, y }), { 0, 0 });
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Prone][AgentType::BodyState::Kneeling]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 93, {x, y}, gPrOff({x, y}), {0, 0});
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Prone][AgentType::BodyState::Kneeling]
-			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 94, { x, y }, gPrOff({ x, y }), { 0, 0 });
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Prone][AgentType::BodyState::Kneeling]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 94, {x, y}, gPrOff({x, y}), {0, 0});
 
 		// Body Kneeling -> Standing animation: 19, 16, 17
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::None]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Kneeling][AgentType::BodyState::Standing]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 19, { x, y });
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Kneeling][AgentType::BodyState::Standing]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 19, {x, y});
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Kneeling][AgentType::BodyState::Standing]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 16, { x, y });
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Kneeling][AgentType::BodyState::Standing]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 16, {x, y});
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Kneeling][AgentType::BodyState::Standing]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 17, { x, y });
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Kneeling][AgentType::BodyState::Standing]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 17, {x, y});
 
 		// Body Standing -> Throwing and back animation: 41
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Standing][AgentType::BodyState::Throwing]
-			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 41, { x, y }, 100, 5, true);
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Standing][AgentType::BodyState::Throwing]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 41, {x, y}, 100, 5, true);
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Standing][AgentType::BodyState::Throwing]
-			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 41, { x, y }, 100, 5, true);
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Standing][AgentType::BodyState::Throwing]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 41, {x, y}, 100, 5, true);
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::None]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Throwing][AgentType::BodyState::Standing]
-			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 41, { x, y }, 100, 5, false, false, true, { 0,0 }, { 0,0 }, false, 3);
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Throwing][AgentType::BodyState::Standing]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 41, {x, y}, 100, 5, false, false, true,
+		                      {0, 0}, {0, 0}, false, 3);
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Throwing][AgentType::BodyState::Standing]
-			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 41, { x, y }, 100, 5, false, false, true, { 0,0 }, { 0,0 }, false, 3);
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Throwing][AgentType::BodyState::Standing]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 41, {x, y}, 100, 5, false, false, true,
+		                      {0, 0}, {0, 0}, false, 3);
 		p->body_state_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::MovementState::None]
-			[AgentType::BodyState::Throwing][AgentType::BodyState::Standing]
-			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 41, { x, y }, 100, 5, false, false, true, { 0,0 }, { 0,0 }, false, 3);
+		                        [AgentType::HandState::AtEase][AgentType::MovementState::None]
+		                        [AgentType::BodyState::Throwing][AgentType::BodyState::Standing]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 41, {x, y}, 100, 5, false, false, true,
+		                      {0, 0}, {0, 0}, false, 3);
 	}
 
 	// Hand state change animation
 	{
 		// Hand Aiming -> Ease standing static animation: 55, 59
 		p->hand_state_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::Aiming][AgentType::HandState::AtEase]
-			[AgentType::MovementState::None][AgentType::BodyState::Standing]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 55, { x, y });
+		                        [AgentType::HandState::Aiming][AgentType::HandState::AtEase]
+		                        [AgentType::MovementState::None][AgentType::BodyState::Standing]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 55, {x, y});
 		p->hand_state_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::Aiming][AgentType::HandState::AtEase]
-			[AgentType::MovementState::None][AgentType::BodyState::Standing]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 59, { x, y });
+		                        [AgentType::HandState::Aiming][AgentType::HandState::AtEase]
+		                        [AgentType::MovementState::None][AgentType::BodyState::Standing]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 59, {x, y});
 
 		// Hand Ease -> Aiming standing static animation: 52, 56
 		p->hand_state_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::HandState::Aiming]
-			[AgentType::MovementState::None][AgentType::BodyState::Standing]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 52, { x, y });
+		                        [AgentType::HandState::AtEase][AgentType::HandState::Aiming]
+		                        [AgentType::MovementState::None][AgentType::BodyState::Standing]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 52, {x, y});
 		p->hand_state_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::HandState::Aiming]
-			[AgentType::MovementState::None][AgentType::BodyState::Standing]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 56, { x, y });
+		                        [AgentType::HandState::AtEase][AgentType::HandState::Aiming]
+		                        [AgentType::MovementState::None][AgentType::BodyState::Standing]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 56, {x, y});
 
 		// Hand Aiming -> Ease kneeling static animation: 63, 67
 		p->hand_state_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::Aiming][AgentType::HandState::AtEase]
-			[AgentType::MovementState::None][AgentType::BodyState::Kneeling]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 63, { x, y });
+		                        [AgentType::HandState::Aiming][AgentType::HandState::AtEase]
+		                        [AgentType::MovementState::None][AgentType::BodyState::Kneeling]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 63, {x, y});
 		p->hand_state_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::Aiming][AgentType::HandState::AtEase]
-			[AgentType::MovementState::None][AgentType::BodyState::Kneeling]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 67, { x, y });
+		                        [AgentType::HandState::Aiming][AgentType::HandState::AtEase]
+		                        [AgentType::MovementState::None][AgentType::BodyState::Kneeling]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 67, {x, y});
 
 		// Hand Ease -> Aiming kneeling static animation: 60, 64
 		p->hand_state_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::HandState::Aiming]
-			[AgentType::MovementState::None][AgentType::BodyState::Kneeling]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 60, { x, y });
+		                        [AgentType::HandState::AtEase][AgentType::HandState::Aiming]
+		                        [AgentType::MovementState::None][AgentType::BodyState::Kneeling]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 60, {x, y});
 		p->hand_state_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::HandState::Aiming]
-			[AgentType::MovementState::None][AgentType::BodyState::Kneeling]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 64, { x, y });
+		                        [AgentType::HandState::AtEase][AgentType::HandState::Aiming]
+		                        [AgentType::MovementState::None][AgentType::BodyState::Kneeling]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 64, {x, y});
 
 		// Hand Aiming -> Ease prone static animation: 71, 75
 		p->hand_state_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::Aiming][AgentType::HandState::AtEase]
-			[AgentType::MovementState::None][AgentType::BodyState::Prone]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 71, { x, y });
+		                        [AgentType::HandState::Aiming][AgentType::HandState::AtEase]
+		                        [AgentType::MovementState::None][AgentType::BodyState::Prone]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 71, {x, y});
 		p->hand_state_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::Aiming][AgentType::HandState::AtEase]
-			[AgentType::MovementState::None][AgentType::BodyState::Prone]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 75, { x, y });
+		                        [AgentType::HandState::Aiming][AgentType::HandState::AtEase]
+		                        [AgentType::MovementState::None][AgentType::BodyState::Prone]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 75, {x, y});
 
 		// Hand Ease -> Aiming prone static animation: 68, 72
 		p->hand_state_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::HandState::Aiming]
-			[AgentType::MovementState::None][AgentType::BodyState::Prone]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 68, { x, y });
+		                        [AgentType::HandState::AtEase][AgentType::HandState::Aiming]
+		                        [AgentType::MovementState::None][AgentType::BodyState::Prone]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 68, {x, y});
 		p->hand_state_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::HandState::Aiming]
-			[AgentType::MovementState::None][AgentType::BodyState::Prone]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 72, { x, y });
+		                        [AgentType::HandState::AtEase][AgentType::HandState::Aiming]
+		                        [AgentType::MovementState::None][AgentType::BodyState::Prone]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 72, {x, y});
 
 		// Hand Aiming -> Ease flying static animation: 87, 91
 		p->hand_state_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::Aiming][AgentType::HandState::AtEase]
-			[AgentType::MovementState::None][AgentType::BodyState::Flying]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 87, { x, y });
+		                        [AgentType::HandState::Aiming][AgentType::HandState::AtEase]
+		                        [AgentType::MovementState::None][AgentType::BodyState::Flying]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 87, {x, y});
 		p->hand_state_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::Aiming][AgentType::HandState::AtEase]
-			[AgentType::MovementState::None][AgentType::BodyState::Flying]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 91, { x, y });
+		                        [AgentType::HandState::Aiming][AgentType::HandState::AtEase]
+		                        [AgentType::MovementState::None][AgentType::BodyState::Flying]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 91, {x, y});
 
 		// Hand Ease -> Aiming flying static animation: 84, 88
 		p->hand_state_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::HandState::Aiming]
-			[AgentType::MovementState::None][AgentType::BodyState::Flying]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 84, { x, y });
+		                        [AgentType::HandState::AtEase][AgentType::HandState::Aiming]
+		                        [AgentType::MovementState::None][AgentType::BodyState::Flying]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 84, {x, y});
 		p->hand_state_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::HandState::Aiming]
-			[AgentType::MovementState::None][AgentType::BodyState::Flying]
-			[{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 88, { x, y });
+		                        [AgentType::HandState::AtEase][AgentType::HandState::Aiming]
+		                        [AgentType::MovementState::None][AgentType::BodyState::Flying]
+		                        [{x, y}] = getAnimationEntry(dataAD, dataUA, dataUF, 88, {x, y});
 
 		// Hand Aiming -> Ease flying moving animation: 87, 91
 		p->hand_state_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::Aiming][AgentType::HandState::AtEase]
-			[AgentType::MovementState::Normal][AgentType::BodyState::Flying]
-			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 87, { x, y }, wFrames);
+		                        [AgentType::HandState::Aiming][AgentType::HandState::AtEase]
+		                        [AgentType::MovementState::Normal][AgentType::BodyState::Flying]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 87, {x, y}, wFrames);
 		p->hand_state_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::Aiming][AgentType::HandState::AtEase]
-			[AgentType::MovementState::Normal][AgentType::BodyState::Flying]
-			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 91, { x, y }, wFrames);
+		                        [AgentType::HandState::Aiming][AgentType::HandState::AtEase]
+		                        [AgentType::MovementState::Normal][AgentType::BodyState::Flying]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 91, {x, y}, wFrames);
 
 		// Hand Ease -> Aiming flying moving animation: 84, 88
 		p->hand_state_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::HandState::Aiming]
-			[AgentType::MovementState::Normal][AgentType::BodyState::Flying]
-			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 84, { x, y }, wFrames);
+		                        [AgentType::HandState::AtEase][AgentType::HandState::Aiming]
+		                        [AgentType::MovementState::Normal][AgentType::BodyState::Flying]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 84, {x, y}, wFrames);
 		p->hand_state_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::HandState::Aiming]
-			[AgentType::MovementState::Normal][AgentType::BodyState::Flying]
-			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 88, { x, y }, wFrames);
+		                        [AgentType::HandState::AtEase][AgentType::HandState::Aiming]
+		                        [AgentType::MovementState::Normal][AgentType::BodyState::Flying]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 88, {x, y}, wFrames);
 
 		// Hand Aiming -> Ease standing overlay moving animation: 79, 83
 		p->hand_state_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::Aiming][AgentType::HandState::AtEase]
-			[AgentType::MovementState::Normal][AgentType::BodyState::Standing]
-			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 79, { x, y }, true, wFrames);
+		                        [AgentType::HandState::Aiming][AgentType::HandState::AtEase]
+		                        [AgentType::MovementState::Normal][AgentType::BodyState::Standing]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 79, {x, y}, true, wFrames);
 		p->hand_state_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::Aiming][AgentType::HandState::AtEase]
-			[AgentType::MovementState::Normal][AgentType::BodyState::Standing]
-			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 83, { x, y }, true, wFrames);
+		                        [AgentType::HandState::Aiming][AgentType::HandState::AtEase]
+		                        [AgentType::MovementState::Normal][AgentType::BodyState::Standing]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 83, {x, y}, true, wFrames);
 
 		// Hand Ease -> Aiming standing overlay moving animation: 76, 80
 		p->hand_state_animations[BattleUnitAnimationPack::ItemWieldMode::OneHanded]
-			[AgentType::HandState::AtEase][AgentType::HandState::Aiming]
-			[AgentType::MovementState::Normal][AgentType::BodyState::Standing]
-			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 76, { x, y }, true, wFrames);
+		                        [AgentType::HandState::AtEase][AgentType::HandState::Aiming]
+		                        [AgentType::MovementState::Normal][AgentType::BodyState::Standing]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 76, {x, y}, true, wFrames);
 		p->hand_state_animations[BattleUnitAnimationPack::ItemWieldMode::TwoHanded]
-			[AgentType::HandState::AtEase][AgentType::HandState::Aiming]
-			[AgentType::MovementState::Normal][AgentType::BodyState::Standing]
-			[{x, y}] =
-			getAnimationEntry(dataAD, dataUA, dataUF, 80, { x, y }, true, wFrames);
+		                        [AgentType::HandState::AtEase][AgentType::HandState::Aiming]
+		                        [AgentType::MovementState::Normal][AgentType::BodyState::Standing]
+		                        [{x, y}] =
+		    getAnimationEntry(dataAD, dataUA, dataUF, 80, {x, y}, true, wFrames);
 	}
 }
-
-
 }

--- a/tools/extractors/extract_unit_animation_packs.cpp
+++ b/tools/extractors/extract_unit_animation_packs.cpp
@@ -33,13 +33,12 @@ sp<BattleUnitAnimationPack::AnimationEntry> e2)
     return e;
 }
 */
-	
-sp<BattleUnitAnimationPack::AnimationEntry>
-InitialGameStateExtractor::getAnimationEntry(const std::vector<AnimationDataAD> &dataAD,
-                  const std::vector<AnimationDataUA> &dataUA, std::vector<AnimationDataUF> &dataUF,
-                  int index, Vec2<int> direction, int frames_per_100_units, int split_point,
-                  bool left_side, bool isOverlay, bool removeItem,
-                  Vec2<int> targetOffset, Vec2<int> beginOffset, bool inverse, int extraEndFrames)
+
+sp<BattleUnitAnimationPack::AnimationEntry> InitialGameStateExtractor::getAnimationEntry(
+    const std::vector<AnimationDataAD> &dataAD, const std::vector<AnimationDataUA> &dataUA,
+    std::vector<AnimationDataUF> &dataUF, int index, Vec2<int> direction, int frames_per_100_units,
+    int split_point, bool left_side, bool isOverlay, bool removeItem, Vec2<int> targetOffset,
+    Vec2<int> beginOffset, bool inverse, int extraEndFrames)
 {
 	static const std::map<Vec2<int>, int> offset_dir_map = {
 	    {{0, -1}, 0}, {{1, -1}, 1}, {{1, 0}, 2},  {{1, 1}, 3},
@@ -54,7 +53,7 @@ InitialGameStateExtractor::getAnimationEntry(const std::vector<AnimationDataAD> 
 	int from = left_side ? 0 : split_point;
 	int to = left_side ? split_point : dataUA[offset_ua].frame_count;
 	int inc = 1;
-	
+
 	for (int i = from; i < to; i++)
 	{
 		int k = inverse ? to - i - 1 : i;

--- a/tools/extractors/extractors.h
+++ b/tools/extractors/extractors.h
@@ -1,9 +1,9 @@
 #pragma once
 #include "game/state/gamestate.h"
 #include "library/strings.h"
+#include "tools/extractors/common/animation.h"
 #include "tools/extractors/common/tacp.h"
 #include "tools/extractors/common/ufo2p.h"
-#include "tools/extractors/common/animation.h"
 
 namespace OpenApoc
 {
@@ -83,44 +83,42 @@ class InitialGameStateExtractor
 
 	void extractSharedBattleResources(GameState &state);
 
-
 	// Unit animation packs functions
 
-	sp<BattleUnitAnimationPack::AnimationEntry>
-		getAnimationEntry(const std::vector<AnimationDataAD> &dataAD,
-			const std::vector<AnimationDataUA> &dataUA, std::vector<AnimationDataUF> &dataUF,
-			int index, Vec2<int> direction, int frames_per_100_units, int split_point,
-			bool left_side, bool isOverlay = false, bool removeItem = false,
-			Vec2<int> targetOffset = { 0, 0 }, Vec2<int> beginOffset = { 0, 0 }, 
-			bool inverse = false, int extraEndFrames = 0);
+	sp<BattleUnitAnimationPack::AnimationEntry> getAnimationEntry(
+	    const std::vector<AnimationDataAD> &dataAD, const std::vector<AnimationDataUA> &dataUA,
+	    std::vector<AnimationDataUF> &dataUF, int index, Vec2<int> direction,
+	    int frames_per_100_units, int split_point, bool left_side, bool isOverlay = false,
+	    bool removeItem = false, Vec2<int> targetOffset = {0, 0}, Vec2<int> beginOffset = {0, 0},
+	    bool inverse = false, int extraEndFrames = 0);
 
 	sp<BattleUnitAnimationPack::AnimationEntry>
-		getAnimationEntry(const std::vector<AnimationDataAD> &dataAD,
-			const std::vector<AnimationDataUA> &dataUA, std::vector<AnimationDataUF> &dataUF,
-			int index, Vec2<int> direction, int frames_per_100_units = 100,
-			bool isOverlay = false, Vec2<int> targetOffset = { 0, 0 },
-			Vec2<int> beginOffset = { 0, 0 })
+	getAnimationEntry(const std::vector<AnimationDataAD> &dataAD,
+	                  const std::vector<AnimationDataUA> &dataUA,
+	                  std::vector<AnimationDataUF> &dataUF, int index, Vec2<int> direction,
+	                  int frames_per_100_units = 100, bool isOverlay = false,
+	                  Vec2<int> targetOffset = {0, 0}, Vec2<int> beginOffset = {0, 0})
 	{
 		return getAnimationEntry(dataAD, dataUA, dataUF, index, direction, frames_per_100_units, 0,
-			false, isOverlay, false, targetOffset, beginOffset);
+		                         false, isOverlay, false, targetOffset, beginOffset);
+	}
+
+	sp<BattleUnitAnimationPack::AnimationEntry> getAnimationEntry(
+	    const std::vector<AnimationDataAD> &dataAD, const std::vector<AnimationDataUA> &dataUA,
+	    std::vector<AnimationDataUF> &dataUF, int index, Vec2<int> direction, bool inverse)
+	{
+		return getAnimationEntry(dataAD, dataUA, dataUF, index, direction, 100, 0, false, false,
+		                         false, {0, 0}, {0, 0}, true);
 	}
 
 	sp<BattleUnitAnimationPack::AnimationEntry>
-		getAnimationEntry(const std::vector<AnimationDataAD> &dataAD,
-			const std::vector<AnimationDataUA> &dataUA, std::vector<AnimationDataUF> &dataUF,
-			int index, Vec2<int> direction, bool inverse)
+	getAnimationEntry(const std::vector<AnimationDataAD> &dataAD,
+	                  const std::vector<AnimationDataUA> &dataUA,
+	                  std::vector<AnimationDataUF> &dataUF, int index, Vec2<int> direction,
+	                  Vec2<int> targetOffset, Vec2<int> beginOffset)
 	{
-		return getAnimationEntry(dataAD, dataUA, dataUF, index, direction, 100, 0,
-			false, false, false, { 0,0 }, { 0,0 }, true);
-	}
-
-	sp<BattleUnitAnimationPack::AnimationEntry>
-		getAnimationEntry(const std::vector<AnimationDataAD> &dataAD,
-			const std::vector<AnimationDataUA> &dataUA, std::vector<AnimationDataUF> &dataUF,
-			int index, Vec2<int> direction, Vec2<int> targetOffset, Vec2<int> beginOffset)
-	{
-		return getAnimationEntry(dataAD, dataUA, dataUF, index, direction, 100, 0, false, false, false,
-			targetOffset, beginOffset);
+		return getAnimationEntry(dataAD, dataUA, dataUF, index, direction, 100, 0, false, false,
+		                         false, targetOffset, beginOffset);
 	}
 
 	Vec2<int> gPrOff(Vec2<int> facing);
@@ -128,8 +126,8 @@ class InitialGameStateExtractor
 	// Unit animation pack extractors
 
 	void extractAnimationPackUnit(sp<BattleUnitAnimationPack> p,
-		const std::vector<AnimationDataAD> &dataAD,
-		const std::vector<AnimationDataUA> &dataUA,
-		std::vector<AnimationDataUF> &dataUF, int x, int y);
+	                              const std::vector<AnimationDataAD> &dataAD,
+	                              const std::vector<AnimationDataUA> &dataUA,
+	                              std::vector<AnimationDataUF> &dataUF, int x, int y);
 };
 }


### PR DESCRIPTION
- units can fire at enemies, tile center (shift) or tile ground
(shift+alt)
- projectiles now properly check for collision with firer (after a
certain invulnerability time given for projectile to depart from firer's
weapon)
- item's collision works the same way
- (this allows for unit which teleported in the way of its own
projectile/item to properly collide with it)
- projectiles now have impact and fire sound (both work in battlescape)
- focus target arrows drawing implemented (real time target selection)