### PR TITLE
Add a "Portable" config mode

### DIFF
--- a/framework/configfile.cpp
+++ b/framework/configfile.cpp
@@ -146,6 +146,8 @@ class ConfigFileImpl
 		return false;
 	}
 
+	bool loaded() const { return this->parsed; }
+
 	bool save()
 	{
 		// Don't try to save if we've not successfully loaded anything
@@ -432,6 +434,8 @@ bool ConfigFile::parseOptions(int argc, char *argv[])
 {
 	return this->pimpl->parseOptions(argc, argv);
 }
+
+bool ConfigFile::loaded() const { return this->pimpl->loaded(); }
 
 void ConfigFile::showHelp() { this->pimpl->showHelp(); }
 

--- a/framework/configfile.cpp
+++ b/framework/configfile.cpp
@@ -82,7 +82,21 @@ class ConfigFileImpl
 		{
 			PHYSFS_init(programName.cStr());
 		}
-		UString settingsPath(PHYSFS_getPrefDir("OpenApoc", programName.cStr()));
+		UString settingsPath;
+		// If a file called 'portable.txt' exists in $(PWD), use a local config folder instead of a
+		// system one.
+		// This can't go through the normal settings system, as it's used by the normal settings
+		// system...
+		std::ifstream portableFile("./portable.txt");
+		if (portableFile)
+		{
+			LogInfo("portable mode set");
+			settingsPath = programName + "_";
+		}
+		else
+		{
+			settingsPath = PHYSFS_getPrefDir("OpenApoc", programName.cStr());
+		}
 		settingsPath += "settings.conf";
 		// Setup some config-related options
 		this->addOption("", "help", "h", "Show help text and exit");

--- a/framework/configfile.h
+++ b/framework/configfile.h
@@ -18,6 +18,9 @@ class ConfigFile
 	~ConfigFile();
 	bool save();
 
+	// Returns true if the settings have been read
+	bool loaded() const;
+
 	int getInt(const UString key);
 	bool getBool(const UString key);
 	UString getString(const UString key);

--- a/framework/logger.cpp
+++ b/framework/logger.cpp
@@ -183,8 +183,22 @@ static std::chrono::time_point<std::chrono::high_resolution_clock> timeInit =
 
 static void initLogger()
 {
-	loggerInited = true;
 	outFile = NULL;
+
+	// Handle Log calls befoore the settings are read, just output everything to stdout
+
+	if (!ConfigFile::getInstance().loaded())
+	{
+		stderrLogLevel = LogLevel::Debug;
+		fileLogLevel = LogLevel::Nothing;
+		backtraceLogLevel = LogLevel::Nothing;
+		showDialogOnError = false;
+		// Returning withoput setting loggerInited causes this to be called evey Log call until the
+		// config is parsed
+		return;
+	}
+
+	loggerInited = true;
 
 	stderrLogLevel = (LogLevel)stderrLogLevelOption.get();
 	fileLogLevel = (LogLevel)fileLogLevelOption.get();

--- a/portable.txt
+++ b/portable.txt
@@ -1,0 +1,12 @@
+A file called "portable.txt" in the working directory when running any
+executable causes the settings path to default to the current working
+directory, instead of a system-wide location.
+
+This file can have any contents, or be completely empty. It simple must be
+successfully opened.
+
+The config files are then stored in ./${PROGRAM_NAME}_settings.conf - e.g.
+"OpenApoc_settings.conf".
+
+This file ensures that files ran as part of the build, or tests invoked from
+the buildsystem, default to the portable mode.


### PR DESCRIPTION
Having a file called 'portable.txt' in the working directory when running an executable now causes the config file path to default to a local path, instead of a system-wide user path.

This should default-enable that mode for the build by adding a portable.txt in the root of the repository.