### PR TITLE
Resurrect travis build, add 'lint' pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,60 +4,59 @@ dist: trusty
 
 cache: ccache
 
-compiler:
-  - gcc
-  - clang
-
-os:
-  - linux
-  - osx
-
-before_install:
-  - if [ $TRAVIS_OS_NAME = "linux" ]; then ccache -M 1G; ccache -s; fi
-  - if [ $TRAVIS_OS_NAME = "linux" ]; then sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y > /dev/null; fi
-  - if [ $TRAVIS_OS_NAME = "linux" ]; then sudo add-apt-repository "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-4.0 main" -y > /dev/null; fi
-  - if [ $TRAVIS_OS_NAME = "linux" ]; then wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key|sudo apt-key add - > /dev/null; fi
-  - if [ $TRAVIS_OS_NAME = "linux" ]; then sudo apt-get update > /dev/null; fi
-  - if [ $TRAVIS_OS_NAME = "linux" -a $CXX = "clang++" -a $BUILD_TYPE != "Sanitize" ]; then export TIDY=true; fi
-  - if [ $TRAVIS_OS_NAME = "linux" ]; then if [ "$CXX" = "g++" ]; then sudo apt-get install g++-5 -y > /dev/null; fi; fi
-  - if [ $TRAVIS_OS_NAME = "linux" ]; then if [ "$CXX" = "g++" ]; then export CXX="ccache g++-5" CC="ccache gcc-5"; fi; fi
-  - if [ $TRAVIS_OS_NAME = "linux" ]; then if [ "$CXX" = "clang++" ]; then sudo apt-get install clang-4.0 --force-yes -y > /dev/null; fi; fi
-  - if [ $TRAVIS_OS_NAME = "linux" ]; then if [ "$CXX" = "clang++" ]; then export CXX="ccache clang++-4.0" CC="ccache clang-4.0"; fi; fi
-  - if [ $TRAVIS_OS_NAME = "linux" ]; then if [ "${TIDY}" = "true" ]; then sudo apt-get install clang-tidy-4.0 clang-format-4.0 clang-4.0 --force-yes -y > /dev/null; fi; fi
-  - if [ $TRAVIS_OS_NAME = "linux" ]; then sudo apt-get install libunwind8-dev libsdl2-dev libboost-locale-dev libboost-filesystem-dev libboost-program-options-dev -y > /dev/null; fi
-  - if [ $TRAVIS_OS_NAME = "osx" ]; then brew update && brew install sdl2 xz ; fi
-  - ${CXX} --version
-  - ${CC} --version
-  - mkdir ~/dependency-prefix
-  - export PKG_CONFIG_PATH=~/dependency-prefix/lib/pkgconfig
-  - wget http://s2.jonnyh.net/pub/cd_minimal.iso.xz -O data/cd.iso.xz
-  - xz -d data/cd.iso.xz
-# setup some default settings
-  - export LSAN_OPTIONS="exitcode=0"
-  - export NUM_CORES=$(grep '^processor' /proc/cpuinfo|wc -l)
-# Try to ignore hyperthreading
-  - export NUM_REAL_CORES=$(grep '^core id' /proc/cpuinfo|sort -u|wc -l)
-  - echo "Num cores ${NUM_CORES} Real cores ${NUM_REAL_CORES}"
-
-env:
-  - BUILD_TYPE="RelWithDebInfo"
-  - BUILD_TYPE="Sanitize"
+#compiler:
+#  - gcc
+#  - clang
 
 matrix:
-  exclude:
-    - compiler: gcc
-      env: BUILD_TYPE="Sanitize"
-    - os: osx
-      env: BUILD_TYPE="Sanitize"
+  include:
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+      env:
+        - MATRIX_ENV="PASS=build CXX='ccache g++-5' CC='ccache gcc-5' BUILD_TYPE=RelWithDebInfo"
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-4.0
+          packages:
+            - clang-4.0
+      env:
+        - MATRIX_ENV="PASS=build CXX='ccache clang++-4.0' CC='ccache clang-4.0' BUILD_TYPE=RelWithDebInfo"
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-4.0
+          packages:
+            - clang-format-4.0
+      env:
+        - MATRIX_ENV="PASS=lint CLANG_FORMAT=clang-format-4.0"
+
+# Passes todo:
+#  - osx
+#  - linux sanitize
+#  - linux static analysis (clang-tidy?)
+
+before_install:
+  - eval "${MATRIX_ENV}"
+  - env
+  - if [ "$TRAVIS_OS_NAME" = "linux" -a "$PASS" = "build" ]; then ./tools/travis-scripts/build_prepare_linux.sh; fi
+  - ${CXX} --version
+  - ${CC} --version
+
 
 before_script:
   - export CFLAGS="-Wall -Wextra" CXXFLAGS="-Wall -Wextra"
-  - $(which time) cmake . -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCLANG_TIDY=clang-tidy-4.0 -DCLANG_FORMAT=clang-format-4.0 -DENABLE_TESTS=ON -DCMAKE_C_FLAGS="${CFLAGS}" -DCMAKE_CXX_FLAGS="${CXXFLAGS}" -DENABLE_COTIRE=OFF
-# Do the format before the script so the output is cleaner - just showing the diff (if any) and the tidy results
-  - if [ "${TIDY}" = "true" ]; then make format -j2 > /dev/null; fi
+  - if [ "$PASS" = "build" ]; then $(which time) cmake . -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCLANG_TIDY=clang-tidy-4.0 -DCLANG_FORMAT=clang-format-4.0 -DENABLE_TESTS=ON -DCMAKE_C_FLAGS="${CFLAGS}" -DCMAKE_CXX_FLAGS="${CXXFLAGS}" -DENABLE_COTIRE=OFF; fi
+
 
 script:
 # Create the GameState as that triggers the generated source commands
-  - $(which time) make -j2 && `which time` ctest -V -j 2 && git --no-pager diff --ignore-submodules --stat
-  - if [ "${TIDY}" = "true" ]; then $(which time) make tidy; fi
-  - if [ $TRAVIS_OS_NAME = "linux" ]; then ccache -s; fi
+  - if [ "$PASS" = "build" ]; then echo "Building revision $(git describe --tags --all --long --always)"; $(which time) make -j2 && `which time` ctest -V -j 2; fi
+  - if [ "$PASS" = "lint" ]; then echo "Linting range ${TRAVIS_COMMIT_RANGE}"; ./tools/lint.sh ${TRAVIS_COMMIT_RANGE}; fi

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -1,0 +1,42 @@
+#! /bin/bash
+#
+# A clang-format lint script. Usage:
+# ./lint.sh
+#   Runs clang-format on the current git stage
+# ./lint.sh revision..range
+#   Runs clang-format on the specified range of commits
+
+set -eo pipefail
+
+[ -z "${CLANG_FORMAT}" ] && CLANG_FORMAT="clang-format"
+
+if [ -z "$(command -v ${CLANG_FORMAT})" ]; then
+  echo >&2 "clang format binary \"${CLANG_FORMAT}\" not found"
+  exit 1;
+fi;
+
+# Default to 'cached', or the revision passed as an argument
+GIT_REVISION=${1:---cached}
+
+MODIFIED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB ${GIT_REVISION})
+
+
+RET=0
+
+for f in ${MODIFIED_FILES}; do
+  # Skip any non C++ files
+  if ! echo "${f}" | egrep -q "[.](cpp|h)$"; then
+    continue;
+  fi
+
+  OUTPUT=$(${CLANG_FORMAT} ${f} | (diff -u  "${f}" - || true))
+  if [ -n "${OUTPUT}" ]; then
+    echo "ERROR: File \"${f}\" doesn't match expected format, diff:"
+	echo
+	echo "${OUTPUT}"
+	RET=1;
+  fi;
+done;
+
+exit ${RET};
+

--- a/tools/travis-scripts/build_prepare_linux.sh
+++ b/tools/travis-scripts/build_prepare_linux.sh
@@ -1,0 +1,16 @@
+#! /bin/bash
+
+set -euo pipefail
+
+echo "Setting ccache variables"
+ccache -M 1G
+ccache -s
+
+echo "Installing dependencies"
+sudo apt-get install libunwind8-dev libsdl2-dev libboost-locale-dev libboost-filesystem-dev libboost-program-options-dev libegl1-mesa-dev libgles2-mesa-dev -y
+
+echo "Fetching minimal cd.iso for build"
+wget http://s2.jonnyh.net/pub/cd_minimal.iso.xz -O data/cd.iso.xz
+xz -d data/cd.iso.xz
+
+exit 0


### PR DESCRIPTION
A recent travis update seems to have broken some packages, so I took
this opportunity to cleanup some things

Also adds a lint script (tools/lint.sh) that runs clang-format on
either:

The current git staging area (IE 'git diff --cached') with no arguments:
./tools/lint.sh
The provided revision range:
./tools/lint.sh master..branch
./tools/lint.sh SHA1..SHA2

No output is required to pass the lint builder. It must be run from the
root of the git repo, as it queries git for the modified files (and it
provides them relative to the root)

TODO:
- Re-add OSX
- Re-add sanitize builds?
- Debug builds?
- Static analysis builds? (clang-tidy?)