### PR TITLE
GCC build fix

### DIFF
--- a/game/state/stateobject.h
+++ b/game/state/stateobject.h
@@ -195,6 +195,12 @@ template <typename T> class StateRef
 		return obj.get() != other;
 	}
 	StateRef<T> &operator=(const StateRef<T> &other) = default;
+	// Explicity handle "object = nullptr", as otherwise gcc doesn't know which overload to use
+	StateRef<T> &operator=(nullptr_t)
+	{
+		this->clear();
+		return *this;
+	}
 	StateRef<T> &operator=(const UString newId)
 	{
 		obj = nullptr;


### PR DESCRIPTION
Adding an explicit StateRef<> operator=(nullptr_t) allows gcc to figure
out:
StateRef<Obj> variable = nullptr;

msvc already allowed this by implicit conversion to constructing to an
sp<> first, but gcc rejected that as ambigious (As it should!) as it
can't tell if 'nullptr' was a GameState* or argument to sp<>
constructor.